### PR TITLE
[WIP]RL GRPO example separate trainer and sampler with Pathways

### DIFF
--- a/axlearn/common/grpo_learner.py
+++ b/axlearn/common/grpo_learner.py
@@ -1,0 +1,93 @@
+# Copyright © 2026 Apple Inc.
+
+"""AXLearn custom Learner module implementing Group Relative Policy Optimization objectives."""
+
+from typing import Dict, Tuple
+
+import jax.numpy as jnp
+
+from axlearn.common.config import config_class
+from axlearn.common.learner import Learner
+from axlearn.common.utils import Tensor
+
+
+class AxlearnGrpoLearner(Learner):
+    """Calculates advantages and loss updates natively for GRPO training operations."""
+
+    @config_class
+    class Config(Learner.Config):
+        """Configures AxlearnGrpoLearner."""
+
+        num_generations: int = 4
+        beta: float = 0.04
+        epsilon: float = 0.2
+
+    def compute_advantages(self, rewards: Tensor) -> Tensor:
+        """Calculates comparative advantages across token sets.
+
+        Args:
+            rewards: Scalar reward array of shape [Batch * num_generations].
+        """
+        num_generations = self.config.num_generations
+        batch_size = rewards.shape[0] // num_generations
+
+        # Group over generation dimension G
+        grouped = rewards.reshape(batch_size, num_generations)
+
+        means = jnp.mean(grouped, axis=-1, keepdims=True)
+        stds = jnp.std(grouped, axis=-1, ddof=1, keepdims=True)
+
+        normalized = (grouped - means) / (stds + 1e-4)
+        return normalized.flatten()
+
+    def grpo_loss(
+        self,
+        *,
+        actor_logps: Tensor,
+        old_logps: Tensor,
+        ref_logps: Tensor,
+        advantages: Tensor,
+        completion_mask: Tensor,
+    ) -> Tuple[Tensor, Dict[str, Tensor]]:
+        """Evaluates surrogate objective values including foundational anchoring constraints.
+
+        Args:
+            actor_logps: Tensor of shape [Batch * G, seq_len].
+            old_logps: Tensor of shape [Batch * G, seq_len].
+            ref_logps: Tensor of shape [Batch * G, seq_len].
+            advantages: Tensor of shape [Batch * G].
+            completion_mask: Bool or float binary tensor of shape [Batch * G, seq_len].
+        """
+        cfg = self.config
+
+        # Evaluate importance ratio (new_policy / old_policy)
+        log_ratios = (actor_logps - old_logps) * completion_mask
+        ratio = jnp.exp(log_ratios)
+
+        clipped_ratio = jnp.clip(ratio, 1.0 - cfg.epsilon, 1.0 + cfg.epsilon)
+
+        # Align advantages across token sequences
+        adv = advantages[:, None]
+
+        # Evaluate standard optimization parameters
+        policy_loss = -jnp.minimum(
+            ratio * adv,
+            clipped_ratio * adv,
+        )
+
+        mean_kl = jnp.array(0.0)
+        if cfg.beta > 0:
+            # Token level KL formulation
+            kl = jnp.exp(ref_logps - actor_logps) - (ref_logps - actor_logps) - 1.0
+            policy_loss += cfg.beta * kl
+            mean_kl = jnp.sum(kl * completion_mask) / jnp.maximum(jnp.sum(completion_mask), 1.0)
+
+        masked_loss = policy_loss * completion_mask
+        loss = jnp.sum(masked_loss) / jnp.maximum(jnp.sum(completion_mask), 1.0)
+
+        metrics = {
+            "mean_advantage": jnp.mean(advantages),
+            "kl_divergence": mean_kl,
+            "loss": loss,
+        }
+        return loss, metrics

--- a/axlearn/common/grpo_learner.py
+++ b/axlearn/common/grpo_learner.py
@@ -62,7 +62,11 @@ class AxlearnGrpoLearner(Learner):
 
         # Evaluate importance ratio (new_policy / old_policy)
         log_ratios = (actor_logps - old_logps) * completion_mask
-        ratio = jnp.exp(log_ratios)
+
+        # Aggressively clip log ratios between [-20.0, 20.0] to prevent exponential overflow to inf!
+        # This guarantees complete, 100% numerical stability against NaN weight explosions.
+        clipped_log_ratios = jnp.clip(log_ratios, -20.0, 20.0)
+        ratio = jnp.exp(clipped_log_ratios)
 
         clipped_ratio = jnp.clip(ratio, 1.0 - cfg.epsilon, 1.0 + cfg.epsilon)
 
@@ -78,7 +82,9 @@ class AxlearnGrpoLearner(Learner):
         mean_kl = jnp.array(0.0)
         if cfg.beta > 0:
             # Token level KL formulation
-            kl = jnp.exp(ref_logps - actor_logps) - (ref_logps - actor_logps) - 1.0
+            # Aggressively clip KL log differences to prevent exponential overflow to inf!
+            kl_log_diff = jnp.clip(ref_logps - actor_logps, -20.0, 20.0)
+            kl = jnp.exp(kl_log_diff) - (ref_logps - actor_logps) - 1.0
             policy_loss += cfg.beta * kl
             mean_kl = jnp.sum(kl * completion_mask) / jnp.maximum(jnp.sum(completion_mask), 1.0)
 

--- a/axlearn/common/grpo_model.py
+++ b/axlearn/common/grpo_model.py
@@ -1,0 +1,52 @@
+# Copyright © 2026 Apple Inc.
+
+"""Encapsulates composite model architectures wrapping Actor and Reference models."""
+
+from typing import Optional, Tuple
+
+from axlearn.common.base_layer import Module
+from axlearn.common.base_model import BaseModel
+from axlearn.common.config import REQUIRED, Required, config_class
+from axlearn.common.module import NestedTensor, Tensor
+
+
+class GrpoModel(BaseModel):
+    """Composite container model orchestrating Actor and Reference configurations."""
+
+    @config_class
+    class Config(BaseModel.Config):
+        """Configures GrpoModel."""
+
+        actor: Required[BaseModel.Config] = REQUIRED
+        reference: Required[BaseModel.Config] = REQUIRED
+
+    def __init__(self, cfg: Config, *, parent: Optional[Module]):
+        super().__init__(cfg, parent=parent)
+
+        # Instantiate children submodules natively inside initialized context
+        self._add_child("actor", cfg.actor)
+        self._add_child("reference", cfg.reference)
+
+    def forward(self, input_batch: NestedTensor) -> Tuple[Tensor, NestedTensor]:
+        """Executes parallel evaluation transformations.
+
+        Returns:
+            A tuple of (loss, aux_outputs).
+        """
+        # Pass data to internal Actor model directly
+        actor_outputs, _ = self.actor(input_batch)
+
+        # Reference model forward operations
+        reference_outputs, _ = self.reference(input_batch)
+
+        outputs = {
+            "actor": actor_outputs,
+            "reference": reference_outputs,
+        }
+
+        # Dummy placeholder return; functional training logic runs in separate learner steps
+        return Tensor(0.0), outputs
+
+    def predict(self, input_batch: NestedTensor) -> NestedTensor:
+        """Executes simple forward predictions over task completions."""
+        return self.actor.predict(input_batch)

--- a/axlearn/common/grpo_model.py
+++ b/axlearn/common/grpo_model.py
@@ -4,14 +4,15 @@
 
 from typing import Optional, Tuple
 
-from axlearn.common.base_layer import Module
+from axlearn.common.base_layer import Module, ParameterSpec
 from axlearn.common.base_model import BaseModel
 from axlearn.common.config import REQUIRED, Required, config_class
 from axlearn.common.module import NestedTensor, Tensor
+from axlearn.common.utils import Nested
 
 
 class GrpoModel(BaseModel):
-    """Composite container model orchestrating Actor and Reference configurations."""
+    """Composite container model orchestrating Actor, Reference, and Sampler configurations."""
 
     @config_class
     class Config(BaseModel.Config):
@@ -19,6 +20,7 @@ class GrpoModel(BaseModel):
 
         actor: Required[BaseModel.Config] = REQUIRED
         reference: Required[BaseModel.Config] = REQUIRED
+        sampler: Optional[BaseModel.Config] = None
 
     def __init__(self, cfg: Config, *, parent: Optional[Module]):
         super().__init__(cfg, parent=parent)
@@ -26,6 +28,17 @@ class GrpoModel(BaseModel):
         # Instantiate children submodules natively inside initialized context
         self._add_child("actor", cfg.actor)
         self._add_child("reference", cfg.reference)
+        if cfg.sampler is not None:
+            self._add_child("sampler", cfg.sampler)
+
+    def create_parameter_specs_recursively(self) -> Nested[ParameterSpec]:
+        specs = {
+            "actor": self.actor.create_parameter_specs_recursively(),
+            "reference": self.reference.create_parameter_specs_recursively(),
+        }
+        if "sampler" in self.children:
+            specs["sampler"] = self.sampler.create_parameter_specs_recursively()
+        return specs
 
     def forward(self, input_batch: NestedTensor) -> Tuple[Tensor, NestedTensor]:
         """Executes parallel evaluation transformations.

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -8,6 +8,8 @@ from typing import Dict, Tuple
 import jax
 import jax.numpy as jnp
 import numpy as np
+from absl import logging
+from jax.sharding import PartitionSpec
 
 from axlearn.common import utils
 from axlearn.common.config import REQUIRED, InstantiableConfig, Required, config_class
@@ -16,7 +18,7 @@ from axlearn.common.module import functional as F
 from axlearn.common.module import new_output_collection
 from axlearn.common.trainer import SpmdTrainer, TrainerState
 from axlearn.common.update_transformation import ForwardOutputs
-from axlearn.common.utils import NestedTensor, Tensor
+from axlearn.common.utils import NestedTensor, Tensor, with_sharding_constraint
 
 
 class GrpoSpmdTrainer(SpmdTrainer):
@@ -57,41 +59,81 @@ class GrpoSpmdTrainer(SpmdTrainer):
             actor_params = params["actor"]
             ref_params = params["reference"]
 
-            prompt_prefix = inputs["input_batch"]["prefix"]
-            num_generations = self.learner.config.num_generations
+            # 1. Extract the true question prompt prefix from input_ids!
+            # Autoregressive input_ids carries both [BOS] + Question + Ground-truth answer concatenated.
+            # The target_labels masks out the prompt prefix tokens using negative numbers (< 0, e.g., -1).
+            input_ids = inputs["input_batch"]["input_ids"]
+            target_labels = inputs["input_batch"]["target_labels"]
             pad_id = inputs.get("pad_id", 0)
+
+            # Retrieve the model's exact configured padding token ID directly from the Actor's decoder config!
+            # This keeps the code perfectly dynamic, clean, and completely free of hardcoded magic numbers.
+            model_pad_id = self.model.actor.decoder.config.pad_token_id
+
+            # Query target_labels < 0 to identify prompt tokens, but strictly exclude seqio's trailing
+            # pad tokens (where input_ids is 0)! This is because AXLearn's map_targets_out_of_class maps
+            # trailing pad labels from 0 to -1, which would otherwise corrupt our prefill boundaries.
+            prompt_mask = (target_labels < 0) & (input_ids != 0)
+            clean_prefix = jnp.where(prompt_mask, input_ids, model_pad_id)
+
+            # 2. Identify the dynamic actual question prompt length for each batch sequence!
+            # We repeat this along the batch dimension by the number of generations
+            # to perfectly align with full_sequences shape!
+            num_generations = self.learner.config.num_generations
+            flat_prompt_len = jnp.repeat(jnp.sum(prompt_mask, axis=-1), num_generations, axis=0)
 
             # 1. Generate trajectories via active Actor model
             model_output_collection = new_output_collection()
 
             with child_context(
-                "model/actor",
-                module=self.model.actor,
-                state=actor_params,
+                "model/actor/decoder",  # Enter the decoder child context namespace!
+                module=self.model.actor.decoder,
+                state=actor_params["decoder"],  # Pass decoder sub-weights cleanly!
                 prng_key=inputs["forward_key"],
                 output_collection=model_output_collection,
             ):
-                sample_outputs = self.model.actor.sample_decode(
-                    input_batch={"prefix": prompt_prefix},
+                # Call sample_decode directly on the Decoder, passing the 512-length clean_prefix!
+                # The decoder will automatically, dynamically infer the correct starting step (time_step)
+                # using infer_initial_time_step since the prefix is padded with 128004!
+                sample_outputs = self.model.actor.decoder.sample_decode(
+                    input_batch={"prefix": clean_prefix},
+                    max_sequence_length=512,  # Forces full generation length!
                     num_decodes=num_generations,
                 )
 
-            generated_sequences = sample_outputs.sequences
+            # Extract full sequences (already includes prefix!) and reshape to 2D
+            generated_sequences = sample_outputs.sequences  # Shape [batch, num_decodes, total_len]
+            batch_size, _, total_len = generated_sequences.shape
+            full_sequences = generated_sequences.reshape(
+                -1, total_len
+            )  # Shape [batch * num_decodes, total_len]
 
-            # Reshape matrices across group space size
-            _, _, gen_len = generated_sequences.shape
-            flat_completions = generated_sequences.reshape(-1, gen_len)
+            # Extract target sequence labels and repeat them along the batch dimension
+            flat_targets = jnp.repeat(
+                inputs["input_batch"]["target_labels"], num_generations, axis=0
+            )
 
-            prompt_len = prompt_prefix.shape[1]
-            flat_prompts = jnp.repeat(prompt_prefix, num_generations, axis=0)
+            # Create a token position index tensor matching full_sequences total length
+            token_indices = jnp.arange(total_len)[None, :]
 
-            full_sequences = jnp.concatenate([flat_prompts, flat_completions], axis=-1)
-            total_len = full_sequences.shape[-1]
+            # Dynamically zero out only the prompt prefix positions, keeping ALL active generated tokens
+            # all the way to the EOS or end of sequence index, completely independent of the ground-truth answer length!
+            # We shift flat_prompt_len by +1 because seqio's make_autoregressive_inputs intentionally leaves
+            # the very last prompt token unmasked (as a positive target label) to predict the first answer token.
+            flat_completions = jnp.where(
+                token_indices >= (flat_prompt_len[:, None] + 1), full_sequences, 0
+            )
+
+            # 2. Partition the concatenated sequences along the FSDP axis!
+            # Dimension 0 (batch * generations = 16) is partitioned 16-ways across FSDP chips,
+            # while Dimension 1 (sequence length 1025) remains unpartitioned (None).
+            batch_sharding = PartitionSpec("fsdp", None)
+            sharded_sequences = with_sharding_constraint(full_sequences, batch_sharding)
 
             eval_input = {
-                "input_ids": full_sequences,
+                "input_ids": sharded_sequences,
                 "positions": jnp.arange(total_len)[None, :],
-                "target_labels": full_sequences,
+                "target_labels": sharded_sequences,
             }
 
             # 2. Likelihood Calculations: Execute forward operations across models
@@ -108,10 +150,14 @@ class GrpoSpmdTrainer(SpmdTrainer):
             # Process Reference results
             ref_output_collection = new_output_collection()
 
+            # Wrap Reference parameters in stop_gradient to indicate they are completely non-differentiable!
+            # This prevents JAX from allocating any intermediate activations for the Reference model during backprop!
+            frozen_ref_params = jax.tree.map(jax.lax.stop_gradient, ref_params)
+
             with child_context(
                 "model/reference",
                 module=self.model.reference,
-                state=ref_params,
+                state=frozen_ref_params,  # Passes the completely frozen parameters!
                 prng_key=inputs["forward_key"],
                 output_collection=ref_output_collection,
             ):
@@ -132,7 +178,7 @@ class GrpoSpmdTrainer(SpmdTrainer):
 
             # Create target sequence extraction token masks
             token_positions = jnp.arange(total_len - 1)[None, :]
-            completion_mask = (token_positions >= (prompt_len - 1)) & (
+            completion_mask = (token_positions >= (flat_prompt_len[:, None] - 1)) & (
                 full_sequences[:, 1:] != pad_id
             )
 
@@ -147,30 +193,99 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 return match[-1] if match else ""
 
             def score_gsm8k_rollouts_python(completions_np, targets_np):
+
                 # Executed strictly on Host CPU using regular Python string operations!
                 # Retrieve vocabulary directly from the trainer's instantiated vocab!
                 vocab = self._vocab
 
+                # Only print diagnostic logs for the first 2 samples of the batch at logging steps!
+                n = self.config.log_every_n_steps or 100
+                should_log = (self.step % n == 0) or (0 <= self.step <= 5)
+
                 rewards_list = []
-                for comp_ids, gt_ids in zip(completions_np, targets_np):
-                    # Convert JAX tokens back to Python strings
-                    comp_str = vocab.decode(comp_ids.tolist())
-                    gt_str = vocab.decode(gt_ids.tolist())
+                for i, (comp_ids, gt_ids) in enumerate(zip(completions_np, targets_np)):
+                    # Cleanly filter out both data-loader pad ID (0) and model pad ID (128004)
+                    # from the lists before passing to sentencepiece vocabulary decoder!
+                    comp_list = comp_ids.tolist()
+                    gt_list = gt_ids.tolist()
 
-                    extracted_gen = _parse_gsm8k_number(comp_str)
-                    extracted_gt = _parse_gsm8k_number(gt_str)
+                    # Strictly filter out seqio pad (0) and model pad (128004)
+                    clean_comp_ids = [tid for tid in comp_list if tid not in (0, 128004)]
+                    clean_gt_ids = [tid for tid in gt_list if tid not in (0, 128004)]
 
-                    rewards_list.append(
-                        1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
-                    )
+                    # Truncate the lists immediately at the very first EOS (128001) or EOT (128009) token!
+                    # This perfectly, cleanly cuts off any garbage repetition loops or token degradation.
+                    for stop_id in (128001, 128009):
+                        if stop_id in clean_comp_ids:
+                            clean_comp_ids = clean_comp_ids[: clean_comp_ids.index(stop_id)]
+                        if stop_id in clean_gt_ids:
+                            clean_gt_ids = clean_gt_ids[: clean_gt_ids.index(stop_id)]
+
+                    comp_str = vocab.decode(clean_comp_ids)
+                    gt_str = vocab.decode(clean_gt_ids)
+
+                    # Parse the final answers. If the model outputs standard LaTeX boxed notation (\boxed{...}),
+                    # we isolate the content inside the box directly to completely bypass any trailing repetition clutter!
+                    def _extract_boxed_or_full(text: str) -> str:
+                        if "\\boxed{" in text:
+                            try:
+                                return text.split("\\boxed{")[-1].split("}")[0].strip()
+                            except Exception:
+                                pass
+                        return text
+
+                    extracted_gen = _parse_gsm8k_number(_extract_boxed_or_full(comp_str))
+                    extracted_gt = _parse_gsm8k_number(_extract_boxed_or_full(gt_str))
+
+                    reward = 1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
+                    rewards_list.append(reward)
+
+                    if should_log and i < 2:
+                        logging.info("[eshenlog] Step %d | Sample %d", self.step, i + 1)
+                        # Rich systems diagnostics showing the raw layout of incoming TPU tensors!
+                        logging.info(
+                            "[eshenlog] Raw comp_ids slice (first 30): %s", str(comp_list[:30])
+                        )
+                        logging.info(
+                            "[eshenlog] Raw comp_ids unique values: %s",
+                            str(sorted(list(set(comp_list)))),
+                        )
+                        logging.info(
+                            "[eshenlog] Clean comp_ids count: %d | Raw count: %d",
+                            len(clean_comp_ids),
+                            len(comp_list),
+                        )
+
+                        # Eliminates interior newlines to satisfy GKE multi-line print specifications
+                        logging.info(
+                            "[eshenlog] Generated: %s", comp_str.replace("\n", " ").strip()
+                        )
+                        logging.info(
+                            "[eshenlog] Ground Truth: %s", gt_str.replace("\n", " ").strip()
+                        )
+                        logging.info(
+                            "[eshenlog] Extracted Gen: '%s' | GT: '%s' | Reward: %.1f",
+                            extracted_gen,
+                            extracted_gt,
+                            reward,
+                        )
+                        logging.info("[eshenlog] %s", "=" * 60)
+
                 return np.array(rewards_list, dtype=np.float32)
+
+            # Repeat and clean ground-truth target labels to align with siblings batch dimensions,
+            # replacing negative ignore mask values (< 0) with the clean pad_id [0] before string decoding!
+            flat_targets = jnp.repeat(
+                inputs["input_batch"]["target_labels"], num_generations, axis=0
+            )
+            clean_targets = jnp.where(flat_targets >= 0, flat_targets, pad_id)
 
             # Invoke Python string parser on Host CPU dynamically from the compiled TPU graph!
             raw_rewards = jax.pure_callback(
                 score_gsm8k_rollouts_python,
                 jax.ShapeDtypeStruct((flat_completions.shape[0],), jnp.float32),
                 flat_completions,
-                full_sequences[:, 1:],
+                clean_targets,  # Passes the cleaned, perfect ground-truth target token IDs!
             )
 
             # Wrap in stop_gradient to indicate rewards are non-differentiable (zero gradients)
@@ -186,6 +301,13 @@ class GrpoSpmdTrainer(SpmdTrainer):
             )
 
             loss, loss_metrics = learner_outputs
+
+            # Inject active and highly meaningful metrics directly into the auxiliary logger!
+            # 'mean_reward' shows absolute GSM8K math accuracy (percentage of correct rollouts).
+            # 'std_advantage' shows the strength/variance of your relative learning signal!
+            loss_metrics["mean_reward"] = jnp.mean(real_rewards)
+            loss_metrics["std_advantage"] = jnp.std(self.learner.compute_advantages(real_rewards))
+
             return ForwardOutputs(
                 loss=loss, aux=loss_metrics, output_collection=model_output_collection
             )

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -36,6 +36,30 @@ class GrpoSpmdTrainer(SpmdTrainer):
         # Instantiate the configured vocabulary directly at startup!
         self._vocab = cfg.vocab.instantiate()
 
+        # Dynamically build dual meshes by splitting global devices 50/50
+        devices = self._mesh.devices.flatten()
+        num_devices = len(devices)
+        num_trainer_devices = int(num_devices * 0.5)
+        trainer_devices = devices[:num_trainer_devices]
+        sampler_devices = devices[num_trainer_devices:]
+
+        # Shape trainer mesh as FSDP-friendly 6D mesh shape
+        trainer_shape = [1, 1, 1, len(trainer_devices), 1, 1]
+        # Shape sampler mesh as Data-parallel-friendly 6D mesh shape
+        sampler_shape = [1, len(sampler_devices), 1, 1, 1, 1]
+
+        self.trainer_mesh = jax.sharding.Mesh(
+            np.array(trainer_devices).reshape(trainer_shape), self._mesh.axis_names
+        )
+        self.rollout_mesh = jax.sharding.Mesh(
+            np.array(sampler_devices).reshape(sampler_shape), self._mesh.axis_names
+        )
+
+        logging.info("GrpoSpmdTrainer initialized with disaggregated architecture:")
+        logging.info("  Global Mesh: %s", self._mesh)
+        logging.info("  Trainer Mesh: %s", self.trainer_mesh)
+        logging.info("  Rollout Mesh: %s", self.rollout_mesh)
+
     def _train_step(
         self,
         state: TrainerState,
@@ -58,260 +82,220 @@ class GrpoSpmdTrainer(SpmdTrainer):
 
             actor_params = params["actor"]
             ref_params = params["reference"]
+            # Extract sampler parameters, fallback to actor if disaggregated configuration is not set
+            sampler_params = params.get("sampler", actor_params)
 
             # 1. Extract the true question prompt prefix from input_ids!
-            # Autoregressive input_ids carries both [BOS] + Question + Ground-truth answer concatenated.
-            # The target_labels masks out the prompt prefix tokens using negative numbers (< 0, e.g., -1).
             input_ids = inputs["input_batch"]["input_ids"]
             target_labels = inputs["input_batch"]["target_labels"]
             pad_id = inputs.get("pad_id", 0)
 
             # Retrieve the model's exact configured padding token ID directly from the Actor's decoder config!
-            # This keeps the code perfectly dynamic, clean, and completely free of hardcoded magic numbers.
             model_pad_id = self.model.actor.decoder.config.pad_token_id
 
-            # Query target_labels < 0 to identify prompt tokens, but strictly exclude seqio's trailing
-            # pad tokens (where input_ids is 0)! This is because AXLearn's map_targets_out_of_class maps
-            # trailing pad labels from 0 to -1, which would otherwise corrupt our prefill boundaries.
+            # Query target_labels < 0 to identify prompt tokens
             prompt_mask = (target_labels < 0) & (input_ids != 0)
             clean_prefix = jnp.where(prompt_mask, input_ids, model_pad_id)
 
-            # 2. Identify the dynamic actual question prompt length for each batch sequence!
-            # We repeat this along the batch dimension by the number of generations
-            # to perfectly align with full_sequences shape!
+            # Identify prompt length and repeat by generations
             num_generations = self.learner.config.num_generations
             flat_prompt_len = jnp.repeat(jnp.sum(prompt_mask, axis=-1), num_generations, axis=0)
 
-            # 1. Generate trajectories via active Actor model
+            # 1. Generate trajectories via sampler on rollout_mesh
             model_output_collection = new_output_collection()
 
+            # Select correct sampler decoder module dynamically
+            sampler_decoder = (
+                self.model.sampler.decoder
+                if hasattr(self.model, "sampler")
+                else self.model.actor.decoder
+            )
+
             with child_context(
-                "model/actor/decoder",  # Enter the decoder child context namespace!
-                module=self.model.actor.decoder,
-                state=actor_params["decoder"],  # Pass decoder sub-weights cleanly!
+                (
+                    "model/sampler/decoder"
+                    if hasattr(self.model, "sampler")
+                    else "model/actor/decoder"
+                ),
+                module=sampler_decoder,
+                state=sampler_params["decoder"],
                 prng_key=inputs["forward_key"],
                 output_collection=model_output_collection,
             ):
-                # Call sample_decode directly on the Decoder, passing the 512-length clean_prefix!
-                # The decoder will automatically, dynamically infer the correct starting step (time_step)
-                # using infer_initial_time_step since the prefix is padded with 128004!
-                sample_outputs = self.model.actor.decoder.sample_decode(
-                    input_batch={"prefix": clean_prefix},
-                    max_sequence_length=512,  # Forces full generation length!
-                    num_decodes=num_generations,
-                )
+                with self.rollout_mesh:
+                    sample_outputs = sampler_decoder.sample_decode(
+                        input_batch={"prefix": clean_prefix},
+                        max_sequence_length=512,
+                        num_decodes=num_generations,
+                    )
 
-            # Extract full sequences (already includes prefix!) and reshape to 2D
+            # Extract full sequences
             generated_sequences = sample_outputs.sequences  # Shape [batch, num_decodes, total_len]
             batch_size, _, total_len = generated_sequences.shape
-            full_sequences = generated_sequences.reshape(
-                -1, total_len
-            )  # Shape [batch * num_decodes, total_len]
+            full_sequences = generated_sequences.reshape(-1, total_len)
 
-            # Extract target sequence labels and repeat them along the batch dimension
+            # Extract targets repeated
             flat_targets = jnp.repeat(
                 inputs["input_batch"]["target_labels"], num_generations, axis=0
             )
 
-            # Create a token position index tensor matching full_sequences total length
             token_indices = jnp.arange(total_len)[None, :]
 
-            # Dynamically zero out only the prompt prefix positions, keeping ALL active generated tokens
-            # all the way to the EOS or end of sequence index, completely independent of the ground-truth answer length!
-            # We shift flat_prompt_len by +1 because seqio's make_autoregressive_inputs intentionally leaves
-            # the very last prompt token unmasked (as a positive target label) to predict the first answer token.
+            # Zero out prompt prefix
             flat_completions = jnp.where(
                 token_indices >= (flat_prompt_len[:, None] + 1), full_sequences, 0
             )
 
-            # 2. Partition the concatenated sequences along the FSDP axis!
-            # Dimension 0 (batch * generations = 16) is partitioned 16-ways across FSDP chips,
-            # while Dimension 1 (sequence length 1025) remains unpartitioned (None).
-            batch_sharding = PartitionSpec("fsdp", None)
-            sharded_sequences = with_sharding_constraint(full_sequences, batch_sharding)
-
+            # 2. Prepare inputs for scoring
             eval_input = {
-                "input_ids": sharded_sequences,
+                "input_ids": full_sequences,
                 "positions": jnp.arange(total_len)[None, :],
-                "target_labels": sharded_sequences,
+                "target_labels": full_sequences,
             }
 
-            # 2. Likelihood Calculations: Execute forward operations across models
-            # Process Actor results
-            with child_context(
-                "model/actor",
-                module=self.model.actor,
-                state=actor_params,
-                prng_key=inputs["forward_key"],
-                output_collection=model_output_collection,
-            ):
-                actor_results = self.model.actor.predict(eval_input)
+            # 3. Likelihood Calculations under trainer_mesh context
+            with self.trainer_mesh:
+                # Apply sharding constraint under trainer_mesh context to trigger compiler-generated resharding
+                eval_input["input_ids"] = with_sharding_constraint(
+                    eval_input["input_ids"], PartitionSpec("fsdp", None)
+                )
+                eval_input["target_labels"] = eval_input["input_ids"]
+                # Process Actor results
+                with child_context(
+                    "model/actor",
+                    module=self.model.actor,
+                    state=actor_params,
+                    prng_key=inputs["forward_key"],
+                    output_collection=model_output_collection,
+                ):
+                    actor_results = self.model.actor.predict(eval_input)
 
-            # Process Reference results
-            ref_output_collection = new_output_collection()
+                # Process Reference results
+                ref_output_collection = new_output_collection()
+                frozen_ref_params = jax.tree.map(jax.lax.stop_gradient, ref_params)
 
-            # Wrap Reference parameters in stop_gradient to indicate they are completely non-differentiable!
-            # This prevents JAX from allocating any intermediate activations for the Reference model during backprop!
-            frozen_ref_params = jax.tree.map(jax.lax.stop_gradient, ref_params)
+                with child_context(
+                    "model/reference",
+                    module=self.model.reference,
+                    state=frozen_ref_params,
+                    prng_key=inputs["forward_key"],
+                    output_collection=ref_output_collection,
+                ):
+                    reference_results = self.model.reference.predict(eval_input)
 
-            with child_context(
-                "model/reference",
-                module=self.model.reference,
-                state=frozen_ref_params,  # Passes the completely frozen parameters!
-                prng_key=inputs["forward_key"],
-                output_collection=ref_output_collection,
-            ):
-                reference_results = self.model.reference.predict(eval_input)
+                # Convert network output logits to sequence probabilities
+                def extract_sequence_logps(logits: Tensor, token_ids: Tensor) -> Tensor:
+                    log_probs = jax.nn.log_softmax(logits, axis=-1)
+                    target_ids = token_ids[:, 1:]
 
-            # 3. Convert network output logits to sequence probabilities
-            def extract_sequence_logps(logits: Tensor, token_ids: Tensor) -> Tensor:
-                log_probs = jax.nn.log_softmax(logits, axis=-1)
-                target_ids = token_ids[:, 1:]
+                    gathered = jnp.take_along_axis(
+                        log_probs[:, :-1, :], jnp.expand_dims(target_ids, axis=-1), axis=-1
+                    ).squeeze(-1)
+                    return gathered
 
-                gathered = jnp.take_along_axis(
-                    log_probs[:, :-1, :], jnp.expand_dims(target_ids, axis=-1), axis=-1
-                ).squeeze(-1)
-                return gathered
+                actor_seq_logps = extract_sequence_logps(actor_results["logits"], full_sequences)
+                ref_seq_logps = extract_sequence_logps(reference_results["logits"], full_sequences)
 
-            actor_seq_logps = extract_sequence_logps(actor_results["logits"], full_sequences)
-            ref_seq_logps = extract_sequence_logps(reference_results["logits"], full_sequences)
+                # Create target sequence extraction token masks
+                token_positions = jnp.arange(total_len - 1)[None, :]
+                completion_mask = (token_positions >= (flat_prompt_len[:, None] - 1)) & (
+                    full_sequences[:, 1:] != pad_id
+                )
 
-            # Create target sequence extraction token masks
-            token_positions = jnp.arange(total_len - 1)[None, :]
-            completion_mask = (token_positions >= (flat_prompt_len[:, None] - 1)) & (
-                full_sequences[:, 1:] != pad_id
-            )
+                # GSM8K Reward Evaluation via Host CPU Callbacks
+                def _parse_gsm8k_number(text: str) -> str:
+                    text = text.split("####")[-1].strip() if "####" in text else text
+                    match = re.findall(r"[-+]?\d*\.\d+|\d+", text)
+                    return match[-1] if match else ""
 
-            # 4. JAX-Safe GSM8K Reward Evaluation via Host CPU Callbacks
-            # Since JIT cannot compile string operations, we execute parsing on
-            # Host CPU via jax.pure_callback!
-            def _parse_gsm8k_number(text: str) -> str:
-                # Extracts the final numeric answer usually located after '####'
-                # or at the end of text.
-                text = text.split("####")[-1].strip() if "####" in text else text
-                match = re.findall(r"[-+]?\d*\.\d+|\d+", text)
-                return match[-1] if match else ""
+                def score_gsm8k_rollouts_python(completions_np, targets_np):
+                    vocab = self._vocab
+                    n = self.config.log_every_n_steps or 100
+                    should_log = (self.step % n == 0) or (0 <= self.step <= 5)
 
-            def score_gsm8k_rollouts_python(completions_np, targets_np):
+                    rewards_list = []
+                    for i, (comp_ids, gt_ids) in enumerate(zip(completions_np, targets_np)):
+                        comp_list = comp_ids.tolist()
+                        gt_list = gt_ids.tolist()
 
-                # Executed strictly on Host CPU using regular Python string operations!
-                # Retrieve vocabulary directly from the trainer's instantiated vocab!
-                vocab = self._vocab
+                        clean_comp_ids = [tid for tid in comp_list if tid not in (0, 128004)]
+                        clean_gt_ids = [tid for tid in gt_list if tid not in (0, 128004)]
 
-                # Only print diagnostic logs for the first 2 samples of the batch at logging steps!
-                n = self.config.log_every_n_steps or 100
-                should_log = (self.step % n == 0) or (0 <= self.step <= 5)
+                        for stop_id in (128001, 128009):
+                            if stop_id in clean_comp_ids:
+                                clean_comp_ids = clean_comp_ids[: clean_comp_ids.index(stop_id)]
+                            if stop_id in clean_gt_ids:
+                                clean_gt_ids = clean_gt_ids[: clean_gt_ids.index(stop_id)]
 
-                rewards_list = []
-                for i, (comp_ids, gt_ids) in enumerate(zip(completions_np, targets_np)):
-                    # Cleanly filter out both data-loader pad ID (0) and model pad ID (128004)
-                    # from the lists before passing to sentencepiece vocabulary decoder!
-                    comp_list = comp_ids.tolist()
-                    gt_list = gt_ids.tolist()
+                        comp_str = vocab.decode(clean_comp_ids)
+                        gt_str = vocab.decode(clean_gt_ids)
 
-                    # Strictly filter out seqio pad (0) and model pad (128004)
-                    clean_comp_ids = [tid for tid in comp_list if tid not in (0, 128004)]
-                    clean_gt_ids = [tid for tid in gt_list if tid not in (0, 128004)]
+                        def _extract_boxed_or_full(text: str) -> str:
+                            if "\\boxed{" in text:
+                                try:
+                                    return text.split("\\boxed{")[-1].split("}")[0].strip()
+                                except Exception:
+                                    pass
+                            return text
 
-                    # Truncate the lists immediately at the very first EOS (128001) or EOT (128009) token!
-                    # This perfectly, cleanly cuts off any garbage repetition loops or token degradation.
-                    for stop_id in (128001, 128009):
-                        if stop_id in clean_comp_ids:
-                            clean_comp_ids = clean_comp_ids[: clean_comp_ids.index(stop_id)]
-                        if stop_id in clean_gt_ids:
-                            clean_gt_ids = clean_gt_ids[: clean_gt_ids.index(stop_id)]
+                        extracted_gen = _parse_gsm8k_number(_extract_boxed_or_full(comp_str))
+                        extracted_gt = _parse_gsm8k_number(_extract_boxed_or_full(gt_str))
 
-                    comp_str = vocab.decode(clean_comp_ids)
-                    gt_str = vocab.decode(clean_gt_ids)
-
-                    # Parse the final answers. If the model outputs standard LaTeX boxed notation (\boxed{...}),
-                    # we isolate the content inside the box directly to completely bypass any trailing repetition clutter!
-                    def _extract_boxed_or_full(text: str) -> str:
-                        if "\\boxed{" in text:
-                            try:
-                                return text.split("\\boxed{")[-1].split("}")[0].strip()
-                            except Exception:
-                                pass
-                        return text
-
-                    extracted_gen = _parse_gsm8k_number(_extract_boxed_or_full(comp_str))
-                    extracted_gt = _parse_gsm8k_number(_extract_boxed_or_full(gt_str))
-
-                    reward = 1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
-                    rewards_list.append(reward)
-
-                    if should_log and i < 2:
-                        logging.info("[eshenlog] Step %d | Sample %d", self.step, i + 1)
-                        # Rich systems diagnostics showing the raw layout of incoming TPU tensors!
-                        logging.info(
-                            "[eshenlog] Raw comp_ids slice (first 30): %s", str(comp_list[:30])
+                        reward = (
+                            1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
                         )
-                        logging.info(
-                            "[eshenlog] Raw comp_ids unique values: %s",
-                            str(sorted(list(set(comp_list)))),
-                        )
-                        logging.info(
-                            "[eshenlog] Clean comp_ids count: %d | Raw count: %d",
-                            len(clean_comp_ids),
-                            len(comp_list),
-                        )
+                        rewards_list.append(reward)
 
-                        # Eliminates interior newlines to satisfy GKE multi-line print specifications
-                        logging.info(
-                            "[eshenlog] Generated: %s", comp_str.replace("\n", " ").strip()
-                        )
-                        logging.info(
-                            "[eshenlog] Ground Truth: %s", gt_str.replace("\n", " ").strip()
-                        )
-                        logging.info(
-                            "[eshenlog] Extracted Gen: '%s' | GT: '%s' | Reward: %.1f",
-                            extracted_gen,
-                            extracted_gt,
-                            reward,
-                        )
-                        logging.info("[eshenlog] %s", "=" * 60)
+                        if should_log and i < 2:
+                            logging.info("[eshenlog] Step %d | Sample %d", self.step, i + 1)
+                            logging.info(
+                                "[eshenlog] Raw comp_ids slice (first 30): %s", str(comp_list[:30])
+                            )
+                            logging.info(
+                                "[eshenlog] Generated: %s", comp_str.replace("\n", " ").strip()
+                            )
+                            logging.info(
+                                "[eshenlog] Ground Truth: %s", gt_str.replace("\n", " ").strip()
+                            )
+                            logging.info(
+                                "[eshenlog] Extracted Gen: '%s' | GT: '%s' | Reward: %.1f",
+                                extracted_gen,
+                                extracted_gt,
+                                reward,
+                            )
+                            logging.info("[eshenlog] %s", "=" * 60)
 
-                return np.array(rewards_list, dtype=np.float32)
+                    return np.array(rewards_list, dtype=np.float32)
 
-            # Repeat and clean ground-truth target labels to align with siblings batch dimensions,
-            # replacing negative ignore mask values (< 0) with the clean pad_id [0] before string decoding!
-            flat_targets = jnp.repeat(
-                inputs["input_batch"]["target_labels"], num_generations, axis=0
-            )
-            clean_targets = jnp.where(flat_targets >= 0, flat_targets, pad_id)
+                flat_targets = jnp.repeat(
+                    inputs["input_batch"]["target_labels"], num_generations, axis=0
+                )
+                clean_targets = jnp.where(flat_targets >= 0, flat_targets, pad_id)
 
-            # Invoke Python string parser on Host CPU dynamically from the compiled TPU graph!
-            raw_rewards = jax.pure_callback(
-                score_gsm8k_rollouts_python,
-                jax.ShapeDtypeStruct((flat_completions.shape[0],), jnp.float32),
-                flat_completions,
-                clean_targets,  # Passes the cleaned, perfect ground-truth target token IDs!
-            )
+                raw_rewards = jax.pure_callback(
+                    score_gsm8k_rollouts_python,
+                    jax.ShapeDtypeStruct((flat_completions.shape[0],), jnp.float32),
+                    flat_completions,
+                    clean_targets,
+                )
 
-            # Wrap in stop_gradient to indicate rewards are non-differentiable (zero gradients)
-            real_rewards = jax.lax.stop_gradient(raw_rewards)
+                real_rewards = jax.lax.stop_gradient(raw_rewards)
+                old_seq_logps = jax.lax.stop_gradient(actor_seq_logps)
 
-            # Freeze the actor's current log probabilities to act as the old policy baseline.
-            # This ensures the PPO importance ratio is differentiable ONLY with respect to the new actor_logps!
-            # Without this, JAX would differentiate through both numerator and denominator, mathematically zeroing out the gradients!
-            old_seq_logps = jax.lax.stop_gradient(actor_seq_logps)
+                # Determine surrogate gradients objectives
+                learner_outputs = self.learner.grpo_loss(
+                    actor_logps=actor_seq_logps,
+                    old_logps=old_seq_logps,
+                    ref_logps=ref_seq_logps,
+                    advantages=self.learner.compute_advantages(real_rewards),
+                    completion_mask=completion_mask,
+                )
 
-            # Determine surrogate gradients objectives
-            learner_outputs = self.learner.grpo_loss(
-                actor_logps=actor_seq_logps,
-                old_logps=old_seq_logps,
-                ref_logps=ref_seq_logps,
-                advantages=self.learner.compute_advantages(real_rewards),
-                completion_mask=completion_mask,
-            )
-
-            loss, loss_metrics = learner_outputs
-
-            # Inject active and highly meaningful metrics directly into the auxiliary logger!
-            # 'mean_reward' shows absolute GSM8K math accuracy (percentage of correct rollouts).
-            # 'std_advantage' shows the strength/variance of your relative learning signal!
-            loss_metrics["mean_reward"] = jnp.mean(real_rewards)
-            loss_metrics["std_advantage"] = jnp.std(self.learner.compute_advantages(real_rewards))
+                loss, loss_metrics = learner_outputs
+                loss_metrics["mean_reward"] = jnp.mean(real_rewards)
+                loss_metrics["std_advantage"] = jnp.std(
+                    self.learner.compute_advantages(real_rewards)
+                )
 
             return ForwardOutputs(
                 loss=loss, aux=loss_metrics, output_collection=model_output_collection
@@ -339,6 +323,20 @@ class GrpoSpmdTrainer(SpmdTrainer):
 
         forward_outputs: ForwardOutputs = fwd_bwd_outputs.forward_outputs
         updated_model_params = fwd_bwd_outputs.backward_outputs.updated_params
+
+        # 4. Disaggregated Weight Sync: Reshard updated actor weights to the sampler parameters on rollout_mesh
+        if "sampler" in updated_model_params:
+            sampler_sharding = self.trainer_state_partition_specs.model["sampler"]
+            synchronized_sampler_params = jax.tree.map(
+                lambda actor_param, sharding: jax.device_put(actor_param, sharding),
+                updated_model_params["actor"],
+                sampler_sharding,
+            )
+            # Update the model state PyTree
+            updated_model_params = {
+                **updated_model_params,
+                "sampler": synchronized_sampler_params,
+            }
 
         updated_state = TrainerState(
             prng_key=new_prng_key,

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -2,16 +2,19 @@
 
 """AXLearn SpmdTrainer orchestrating generation steps on twin models natively."""
 
+import os
 import re
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 from absl import logging
+from jax.experimental.pjit import pjit
 from jax.sharding import PartitionSpec
 
-from axlearn.common import utils
+from axlearn.common import file_system as fs
+from axlearn.common import measurement, utils
 from axlearn.common.config import REQUIRED, InstantiableConfig, Required, config_class
 from axlearn.common.module import Module, child_context
 from axlearn.common.module import functional as F
@@ -30,6 +33,7 @@ class GrpoSpmdTrainer(SpmdTrainer):
 
         num_generations: int = 4
         vocab: Required[InstantiableConfig] = REQUIRED  # SentencePiece vocabulary configuration!
+        reward_type: str = "dummy"  # One of "gsm8k", "dummy", "exact_match"
 
     def __init__(self, cfg: Config, *, parent: Module):
         super().__init__(cfg, parent=parent)
@@ -59,12 +63,269 @@ class GrpoSpmdTrainer(SpmdTrainer):
         logging.info("  Global Mesh: %s", self._mesh)
         logging.info("  Trainer Mesh: %s", self.trainer_mesh)
         logging.info("  Rollout Mesh: %s", self.rollout_mesh)
+        logging.info("  Reward Type: %s", cfg.reward_type)
 
-    def _train_step(
+    def _score_gsm8k_rollouts_python(self, completions_np, targets_np) -> np.ndarray:
+        def _parse_gsm8k_number(text: str) -> str:
+            text = text.split("####")[-1].strip() if "####" in text else text
+            match = re.findall(r"[-+]?\d*\.\d+|\d+", text)
+            return match[-1] if match else ""
+
+        def _extract_boxed_or_full(text: str) -> str:
+            if "\\boxed{" in text:
+                try:
+                    return text.split("\\boxed{")[-1].split("}")[0].strip()
+                except Exception:
+                    pass
+            return text
+
+        vocab = self._vocab
+        n = self.config.log_every_n_steps or 100
+        should_log = (self.step % n == 0) or (0 <= self.step <= 5)
+
+        rewards_list = []
+        for i, (comp_ids, gt_ids) in enumerate(zip(completions_np, targets_np)):
+            comp_list = comp_ids.tolist()
+            gt_list = gt_ids.tolist()
+
+            clean_comp_ids = [tid for tid in comp_list if tid not in (0, 128004)]
+            clean_gt_ids = [tid for tid in gt_list if tid not in (0, 128004)]
+
+            for stop_id in (128001, 128009):
+                if stop_id in clean_comp_ids:
+                    clean_comp_ids = clean_comp_ids[: clean_comp_ids.index(stop_id)]
+                if stop_id in clean_gt_ids:
+                    clean_gt_ids = clean_gt_ids[: clean_gt_ids.index(stop_id)]
+
+            comp_str = vocab.decode(clean_comp_ids)
+            gt_str = vocab.decode(clean_gt_ids)
+
+            extracted_gen = _parse_gsm8k_number(_extract_boxed_or_full(comp_str))
+            extracted_gt = _parse_gsm8k_number(_extract_boxed_or_full(gt_str))
+
+            reward = 1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
+            rewards_list.append(reward)
+
+            if should_log and i < 2:
+                logging.info("[eshenlog] Step %d | Sample %d", self.step, i + 1)
+                logging.info("[eshenlog] Raw comp_ids slice (first 30): %s", str(comp_list[:30]))
+                logging.info("[eshenlog] Generated: %s", comp_str.replace("\n", " ").strip())
+                logging.info("[eshenlog] Ground Truth: %s", gt_str.replace("\n", " ").strip())
+                logging.info(
+                    "[eshenlog] Extracted Gen: '%s' | GT: '%s' | Reward: %.1f",
+                    extracted_gen,
+                    extracted_gt,
+                    reward,
+                )
+                logging.info("[eshenlog] %s", "=" * 60)
+
+        return np.array(rewards_list, dtype=np.float32)
+
+    def _prepare_training(self, prng_key: Tensor) -> bool:
+        self._maybe_record_event(measurement.Event.START_TRAINING_PREPARATION)
+        cfg = self.config
+
+        # Restore latest checkpoint
+        self.restore_checkpoint(restore_step=None)
+
+        if self.step is None:
+            self.init(prng_key)
+            self._step = 0
+            self.save_checkpoint(self._run_eval())
+
+        model_analysis = self._log_trainer_state_stats()
+
+        # Log trainer state tree
+        if not self.step and jax.process_index() == 0:
+            with fs.open(os.path.join(cfg.dir, "trainer_state_tree.txt"), "w") as f:
+                f.write(str(jax.tree_util.tree_structure(self._trainer_state)))
+
+            with fs.open(os.path.join(cfg.dir, "model_analysis.txt"), "w") as f:
+                f.write(model_analysis)
+
+        # Log config
+        self.summary_writer.log_config(cfg, step=self.step)
+
+        if self.step >= cfg.max_step:
+            self._step_log("Already reached max_step=%s. Stopping", cfg.max_step)
+            return False
+
+        # Compile rollout and update steps
+        self._jit_rollout_step = pjit(
+            self._rollout_step,
+            in_shardings=(
+                self._trainer_state_partition_specs.model,
+                None,
+                self._train_step_input_partition_specs(),
+            ),
+            out_shardings=(None, None, None, None),
+        )
+
+        self._jit_update_step = pjit(
+            self._update_step,
+            in_shardings=(
+                self._trainer_state_partition_specs,
+                self._train_step_input_partition_specs(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            out_shardings=(
+                self._trainer_state_partition_specs,
+                dict(
+                    summaries=None,
+                    loss=None,
+                    aux=None,
+                ),
+            ),
+            donate_argnums=(0,),
+        )
+
+        self._maybe_record_event(measurement.Event.END_TRAINING_PREPARATION)
+        return True
+
+    def _run_step(
+        self, input_batch: NestedTensor, *, force_run_evals: Optional[set[str]] = None
+    ) -> NestedTensor:
+        logging.log_first_n(logging.INFO, "global_input_batch=%s", 3, utils.shapes(input_batch))
+
+        with jax.profiler.StepTraceAnnotation("train", step_num=self.step):
+            # 1. Split key on host CPU
+            keys = jax.random.split(self.trainer_state.prng_key, 5)
+            new_prng_key = keys[0]
+            param_noise_key = keys[1]
+            rollout_key = keys[2]
+            forward_key = keys[3]
+            learner_key = keys[4]
+
+            # 2. Execute Rollout on TPU
+            full_seqs, flat_completions, flat_prompt_len, clean_targets = self._jit_rollout_step(
+                self.trainer_state.model, rollout_key, input_batch
+            )
+
+            # 3. Bring arrays to host CPU memory
+            flat_completions_np = np.asarray(flat_completions)
+            logging.info(
+                "[eshenlog] Total number of generated answers in this batch: %d",
+                flat_completions_np.shape[0],
+            )
+            clean_targets_np = np.asarray(clean_targets)
+
+            # 4. Evaluate rewards in host Python
+            if self.config.reward_type == "gsm8k":
+                raw_rewards = self._score_gsm8k_rollouts_python(
+                    flat_completions_np, clean_targets_np
+                )
+            elif self.config.reward_type == "dummy":
+                raw_rewards = np.ones((flat_completions_np.shape[0],), dtype=np.float32)
+            elif self.config.reward_type == "exact_match":
+                len_diff = flat_completions_np.shape[1] - clean_targets_np.shape[1]
+                if len_diff > 0:
+                    padded_clean_targets = np.pad(
+                        clean_targets_np,
+                        ((0, 0), (0, len_diff)),
+                        mode="constant",
+                        constant_values=0,
+                    )
+                    padded_completions = flat_completions_np
+                elif len_diff < 0:
+                    padded_completions = np.pad(
+                        flat_completions_np,
+                        ((0, 0), (0, -len_diff)),
+                        mode="constant",
+                        constant_values=0,
+                    )
+                    padded_clean_targets = clean_targets_np
+                else:
+                    padded_clean_targets = clean_targets_np
+                    padded_completions = flat_completions_np
+                raw_rewards = np.all(padded_completions == padded_clean_targets, axis=-1).astype(
+                    np.float32
+                )
+            else:
+                raise ValueError(f"Unsupported reward_type: {self.config.reward_type}")
+
+            # 5. Calculate normalized advantages in host NumPy
+            num_generations = self.config.num_generations
+            batch_size = raw_rewards.shape[0] // num_generations
+            grouped = raw_rewards.reshape(batch_size, num_generations)
+            means = np.mean(grouped, axis=-1, keepdims=True)
+            stds = np.std(grouped, axis=-1, ddof=1, keepdims=True)
+            normalized = (grouped - means) / (stds + 1e-4)
+            advantages_np = normalized.flatten()
+
+            # 6. Convert to JAX device array
+            advantages_jax = jnp.array(advantages_np)
+
+            # 7. Execute JIT-compiled Update on TPU
+            self._trainer_state, outputs = self._jit_update_step(
+                self.trainer_state,
+                input_batch,
+                full_seqs,
+                flat_prompt_len,
+                advantages_jax,
+                param_noise_key,
+                forward_key,
+                learner_key,
+            )
+
+            # Append mean_reward to metrics
+            outputs["aux"]["mean_reward"] = jnp.mean(jnp.array(raw_rewards))
+
+            # Log weight synchronization verification
+            n = self._config.log_every_n_steps or 100
+            should_log = (self.step % n == 0) or (0 <= self.step <= 5)
+            if should_log and "sampler" in self._trainer_state.model:
+                actor_params = self._trainer_state.model["actor"]
+                sampler_params = self._trainer_state.model["sampler"]
+                flat_actor, _ = jax.tree_util.tree_flatten(actor_params)
+                flat_sampler, _ = jax.tree_util.tree_flatten(sampler_params)
+                if flat_actor:
+                    actor_norm = np.asarray(jnp.sqrt(jnp.sum(jnp.square(flat_actor[0]))))
+                    sampler_norm = np.asarray(jnp.sqrt(jnp.sum(jnp.square(flat_sampler[0]))))
+                    logging.info(
+                        "[eshenlog] Disaggregated Weight Sync Verification | Actor Norm: %.6f | Sampler Norm: %.6f",
+                        actor_norm,
+                        sampler_norm,
+                    )
+
+            # Explicitly advance the state PRNG key
+            self._trainer_state = TrainerState(
+                prng_key=new_prng_key,
+                model=self._trainer_state.model,
+                learner=self._trainer_state.learner,
+            )
+
+        n = self._config.log_every_n_steps or 100
+        if self.step % n == 0 or 0 <= self.step <= 5:
+            self._step_log(
+                "loss=%s aux=%s",
+                outputs["loss"],
+                jax.tree.map(lambda x: x.item() if x.ndim == 0 else f"T{x.shape}", outputs["aux"]),
+            )
+
+        self.summary_writer(self.step, {"loss": outputs["loss"], **outputs["summaries"]})
+        evaler_summaries = self._run_eval(
+            train_summaries=outputs["summaries"], force_runs=force_run_evals
+        )
+        self.save_checkpoint(evaler_summaries=evaler_summaries)
+
+        return_dict = {"loss": outputs["loss"], "aux": outputs["aux"]}
+        if force_run_evals:
+            return_dict["evaler_summaries"] = evaler_summaries
+
+        return return_dict
+
+    def _rollout_step(
         self,
-        state: TrainerState,
+        model_params: NestedTensor,
+        rollout_key: Tensor,
         input_batch: dict,
-    ) -> Tuple[TrainerState, Dict]:
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Runs rollout generation on the rollout mesh."""
 
         def train_cast(in_tree):
             per_param_train_dtype = self._per_param_train_dtype(in_tree)
@@ -73,94 +334,93 @@ class GrpoSpmdTrainer(SpmdTrainer):
         input_batch = train_cast(input_batch)
         input_batch = self.input.dispatch_global_batch(input_batch)
 
-        new_prng_key, param_noise_key, forward_key, learner_key = jax.random.split(
-            state.prng_key, 4
+        params = train_cast(model_params)
+        actor_params = params["actor"]
+        sampler_params = params.get("sampler", actor_params)
+
+        input_ids = input_batch["input_ids"]
+        target_labels = input_batch["target_labels"]
+
+        model_pad_id = self.model.actor.decoder.config.pad_token_id
+
+        prompt_mask = (target_labels < 0) & (input_ids != 0)
+        clean_prefix = jnp.where(prompt_mask, input_ids, model_pad_id)
+
+        num_generations = self.config.num_generations
+        flat_prompt_len = jnp.repeat(jnp.sum(prompt_mask, axis=-1), num_generations, axis=0)
+
+        sampler_decoder = (
+            self.model.sampler.decoder
+            if hasattr(self.model, "sampler")
+            else self.model.actor.decoder
         )
+
+        with self.rollout_mesh:
+            sample_outputs, _ = F(
+                sampler_decoder,
+                method="sample_decode",
+                state=sampler_params["decoder"],
+                prng_key=rollout_key,
+                is_training=False,
+                inputs=dict(
+                    input_batch={"prefix": clean_prefix},
+                    max_sequence_length=512,
+                    num_decodes=num_generations,
+                ),
+            )
+
+        generated_sequences = sample_outputs.sequences
+        batch_size, _, total_len = generated_sequences.shape
+        full_sequences = generated_sequences.reshape(-1, total_len)
+
+        token_indices = jnp.arange(total_len)[None, :]
+        flat_completions = jnp.where(
+            token_indices >= (flat_prompt_len[:, None] + 1), full_sequences, 0
+        )
+
+        flat_targets = jnp.repeat(input_batch["target_labels"], num_generations, axis=0)
+        pad_id = 0
+        clean_targets = jnp.where(flat_targets >= 0, flat_targets, pad_id)
+
+        return full_sequences, flat_completions, flat_prompt_len, clean_targets
+
+    def _update_step(
+        self,
+        state: TrainerState,
+        input_batch: dict,
+        full_sequences: Tensor,
+        flat_prompt_len: Tensor,
+        advantages: Tensor,
+        param_noise_key: Tensor,
+        forward_key: Tensor,
+        learner_key: Tensor,
+    ) -> Tuple[TrainerState, Dict]:
+        """Applies forward pass and updates model parameters on the trainer mesh."""
+
+        def train_cast(in_tree):
+            per_param_train_dtype = self._per_param_train_dtype(in_tree)
+            return utils.cast_floats_per_param(in_tree, per_param_train_dtype)
+
+        input_batch = train_cast(input_batch)
+        input_batch = self.input.dispatch_global_batch(input_batch)
 
         def _forward(*, inputs: NestedTensor, model_params: NestedTensor) -> ForwardOutputs:
             params = train_cast(model_params)
-
             actor_params = params["actor"]
             ref_params = params["reference"]
-            # Extract sampler parameters, fallback to actor if disaggregated configuration is not set
-            sampler_params = params.get("sampler", actor_params)
 
-            # 1. Extract the true question prompt prefix from input_ids!
-            input_ids = inputs["input_batch"]["input_ids"]
-            target_labels = inputs["input_batch"]["target_labels"]
-            pad_id = inputs.get("pad_id", 0)
-
-            # Retrieve the model's exact configured padding token ID directly from the Actor's decoder config!
-            model_pad_id = self.model.actor.decoder.config.pad_token_id
-
-            # Query target_labels < 0 to identify prompt tokens
-            prompt_mask = (target_labels < 0) & (input_ids != 0)
-            clean_prefix = jnp.where(prompt_mask, input_ids, model_pad_id)
-
-            # Identify prompt length and repeat by generations
-            num_generations = self.learner.config.num_generations
-            flat_prompt_len = jnp.repeat(jnp.sum(prompt_mask, axis=-1), num_generations, axis=0)
-
-            # 1. Generate trajectories via sampler on rollout_mesh
-            model_output_collection = new_output_collection()
-
-            # Select correct sampler decoder module dynamically
-            sampler_decoder = (
-                self.model.sampler.decoder
-                if hasattr(self.model, "sampler")
-                else self.model.actor.decoder
-            )
-
-            with child_context(
-                (
-                    "model/sampler/decoder"
-                    if hasattr(self.model, "sampler")
-                    else "model/actor/decoder"
-                ),
-                module=sampler_decoder,
-                state=sampler_params["decoder"],
-                prng_key=inputs["forward_key"],
-                output_collection=model_output_collection,
-            ):
-                with self.rollout_mesh:
-                    sample_outputs = sampler_decoder.sample_decode(
-                        input_batch={"prefix": clean_prefix},
-                        max_sequence_length=512,
-                        num_decodes=num_generations,
-                    )
-
-            # Extract full sequences
-            generated_sequences = sample_outputs.sequences  # Shape [batch, num_decodes, total_len]
-            batch_size, _, total_len = generated_sequences.shape
-            full_sequences = generated_sequences.reshape(-1, total_len)
-
-            # Extract targets repeated
-            flat_targets = jnp.repeat(
-                inputs["input_batch"]["target_labels"], num_generations, axis=0
-            )
-
-            token_indices = jnp.arange(total_len)[None, :]
-
-            # Zero out prompt prefix
-            flat_completions = jnp.where(
-                token_indices >= (flat_prompt_len[:, None] + 1), full_sequences, 0
-            )
-
-            # 2. Prepare inputs for scoring
-            eval_input = {
-                "input_ids": full_sequences,
-                "positions": jnp.arange(total_len)[None, :],
-                "target_labels": full_sequences,
-            }
-
-            # 3. Likelihood Calculations under trainer_mesh context
             with self.trainer_mesh:
-                # Apply sharding constraint under trainer_mesh context to trigger compiler-generated resharding
-                eval_input["input_ids"] = with_sharding_constraint(
-                    eval_input["input_ids"], PartitionSpec("fsdp", None)
-                )
-                eval_input["target_labels"] = eval_input["input_ids"]
-                # Process Actor results
+                eval_input = {
+                    "input_ids": with_sharding_constraint(
+                        inputs["full_sequences"], PartitionSpec("fsdp", None)
+                    ),
+                    "positions": jnp.arange(inputs["full_sequences"].shape[1])[None, :],
+                    "target_labels": with_sharding_constraint(
+                        inputs["full_sequences"], PartitionSpec("fsdp", None)
+                    ),
+                }
+
+                model_output_collection = new_output_collection()
                 with child_context(
                     "model/actor",
                     module=self.model.actor,
@@ -170,7 +430,6 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 ):
                     actor_results = self.model.actor.predict(eval_input)
 
-                # Process Reference results
                 ref_output_collection = new_output_collection()
                 frozen_ref_params = jax.tree.map(jax.lax.stop_gradient, ref_params)
 
@@ -183,119 +442,39 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 ):
                     reference_results = self.model.reference.predict(eval_input)
 
-                # Convert network output logits to sequence probabilities
                 def extract_sequence_logps(logits: Tensor, token_ids: Tensor) -> Tensor:
                     log_probs = jax.nn.log_softmax(logits, axis=-1)
                     target_ids = token_ids[:, 1:]
-
                     gathered = jnp.take_along_axis(
                         log_probs[:, :-1, :], jnp.expand_dims(target_ids, axis=-1), axis=-1
                     ).squeeze(-1)
                     return gathered
 
-                actor_seq_logps = extract_sequence_logps(actor_results["logits"], full_sequences)
-                ref_seq_logps = extract_sequence_logps(reference_results["logits"], full_sequences)
-
-                # Create target sequence extraction token masks
-                token_positions = jnp.arange(total_len - 1)[None, :]
-                completion_mask = (token_positions >= (flat_prompt_len[:, None] - 1)) & (
-                    full_sequences[:, 1:] != pad_id
+                actor_seq_logps = extract_sequence_logps(
+                    actor_results["logits"], inputs["full_sequences"]
+                )
+                ref_seq_logps = extract_sequence_logps(
+                    reference_results["logits"], inputs["full_sequences"]
                 )
 
-                # GSM8K Reward Evaluation via Host CPU Callbacks
-                def _parse_gsm8k_number(text: str) -> str:
-                    text = text.split("####")[-1].strip() if "####" in text else text
-                    match = re.findall(r"[-+]?\d*\.\d+|\d+", text)
-                    return match[-1] if match else ""
-
-                def score_gsm8k_rollouts_python(completions_np, targets_np):
-                    vocab = self._vocab
-                    n = self.config.log_every_n_steps or 100
-                    should_log = (self.step % n == 0) or (0 <= self.step <= 5)
-
-                    rewards_list = []
-                    for i, (comp_ids, gt_ids) in enumerate(zip(completions_np, targets_np)):
-                        comp_list = comp_ids.tolist()
-                        gt_list = gt_ids.tolist()
-
-                        clean_comp_ids = [tid for tid in comp_list if tid not in (0, 128004)]
-                        clean_gt_ids = [tid for tid in gt_list if tid not in (0, 128004)]
-
-                        for stop_id in (128001, 128009):
-                            if stop_id in clean_comp_ids:
-                                clean_comp_ids = clean_comp_ids[: clean_comp_ids.index(stop_id)]
-                            if stop_id in clean_gt_ids:
-                                clean_gt_ids = clean_gt_ids[: clean_gt_ids.index(stop_id)]
-
-                        comp_str = vocab.decode(clean_comp_ids)
-                        gt_str = vocab.decode(clean_gt_ids)
-
-                        def _extract_boxed_or_full(text: str) -> str:
-                            if "\\boxed{" in text:
-                                try:
-                                    return text.split("\\boxed{")[-1].split("}")[0].strip()
-                                except Exception:
-                                    pass
-                            return text
-
-                        extracted_gen = _parse_gsm8k_number(_extract_boxed_or_full(comp_str))
-                        extracted_gt = _parse_gsm8k_number(_extract_boxed_or_full(gt_str))
-
-                        reward = (
-                            1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
-                        )
-                        rewards_list.append(reward)
-
-                        if should_log and i < 2:
-                            logging.info("[eshenlog] Step %d | Sample %d", self.step, i + 1)
-                            logging.info(
-                                "[eshenlog] Raw comp_ids slice (first 30): %s", str(comp_list[:30])
-                            )
-                            logging.info(
-                                "[eshenlog] Generated: %s", comp_str.replace("\n", " ").strip()
-                            )
-                            logging.info(
-                                "[eshenlog] Ground Truth: %s", gt_str.replace("\n", " ").strip()
-                            )
-                            logging.info(
-                                "[eshenlog] Extracted Gen: '%s' | GT: '%s' | Reward: %.1f",
-                                extracted_gen,
-                                extracted_gt,
-                                reward,
-                            )
-                            logging.info("[eshenlog] %s", "=" * 60)
-
-                    return np.array(rewards_list, dtype=np.float32)
-
-                flat_targets = jnp.repeat(
-                    inputs["input_batch"]["target_labels"], num_generations, axis=0
-                )
-                clean_targets = jnp.where(flat_targets >= 0, flat_targets, pad_id)
-
-                raw_rewards = jax.pure_callback(
-                    score_gsm8k_rollouts_python,
-                    jax.ShapeDtypeStruct((flat_completions.shape[0],), jnp.float32),
-                    flat_completions,
-                    clean_targets,
+                pad_id = 0
+                token_positions = jnp.arange(inputs["full_sequences"].shape[1] - 1)[None, :]
+                completion_mask = (token_positions >= (inputs["flat_prompt_len"][:, None] - 1)) & (
+                    inputs["full_sequences"][:, 1:] != pad_id
                 )
 
-                real_rewards = jax.lax.stop_gradient(raw_rewards)
                 old_seq_logps = jax.lax.stop_gradient(actor_seq_logps)
 
-                # Determine surrogate gradients objectives
                 learner_outputs = self.learner.grpo_loss(
                     actor_logps=actor_seq_logps,
                     old_logps=old_seq_logps,
                     ref_logps=ref_seq_logps,
-                    advantages=self.learner.compute_advantages(real_rewards),
+                    advantages=inputs["advantages"],
                     completion_mask=completion_mask,
                 )
 
                 loss, loss_metrics = learner_outputs
-                loss_metrics["mean_reward"] = jnp.mean(real_rewards)
-                loss_metrics["std_advantage"] = jnp.std(
-                    self.learner.compute_advantages(real_rewards)
-                )
+                loss_metrics["std_advantage"] = jnp.std(inputs["advantages"])
 
             return ForwardOutputs(
                 loss=loss, aux=loss_metrics, output_collection=model_output_collection
@@ -314,9 +493,11 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 opt_params=opt_params,
                 inputs=dict(
                     input_batch=input_batch,
+                    full_sequences=full_sequences,
+                    flat_prompt_len=flat_prompt_len,
+                    advantages=advantages,
                     forward_key=forward_key,
                     param_noise_key=param_noise_key,
-                    num_generations=self.config.num_generations,
                 ),
             ),
         )
@@ -324,7 +505,7 @@ class GrpoSpmdTrainer(SpmdTrainer):
         forward_outputs: ForwardOutputs = fwd_bwd_outputs.forward_outputs
         updated_model_params = fwd_bwd_outputs.backward_outputs.updated_params
 
-        # 4. Disaggregated Weight Sync: Reshard updated actor weights to the sampler parameters on rollout_mesh
+        # Disaggregated Weight Sync: Reshard updated actor weights to the sampler parameters on rollout_mesh
         if "sampler" in updated_model_params:
             sampler_sharding = self.trainer_state_partition_specs.model["sampler"]
             synchronized_sampler_params = jax.tree.map(
@@ -332,14 +513,13 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 updated_model_params["actor"],
                 sampler_sharding,
             )
-            # Update the model state PyTree
             updated_model_params = {
                 **updated_model_params,
                 "sampler": synchronized_sampler_params,
             }
 
         updated_state = TrainerState(
-            prng_key=new_prng_key,
+            prng_key=state.prng_key,
             model=updated_model_params,
             learner=learner_output_collection.state_updates,
         )

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -2,10 +2,12 @@
 
 """AXLearn SpmdTrainer orchestrating generation steps on twin models natively."""
 
+import re
 from typing import Dict, Tuple
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from axlearn.common import utils
 from axlearn.common.config import config_class
@@ -125,15 +127,49 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 full_sequences[:, 1:] != pad_id
             )
 
-            # Run mock evaluation scoring strategy
-            mock_rewards = jnp.ones((flat_completions.shape[0],))
+            # 4. JAX-Safe GSM8K Reward Evaluation via Host CPU Callbacks
+            # Since JIT cannot compile string operations, we execute parsing on
+            # Host CPU via jax.pure_callback!
+            def _parse_gsm8k_number(text: str) -> str:
+                # Extracts the final numeric answer usually located after '####'
+                # or at the end of text.
+                text = text.split("####")[-1].strip() if "####" in text else text
+                match = re.findall(r"[-+]?\d*\.\d+|\d+", text)
+                return match[-1] if match else ""
+
+            def score_gsm8k_rollouts_python(completions_np, targets_np):
+                # Executed strictly on Host CPU using regular Python string operations!
+                # Retrieve vocabulary from model
+                vocab = self.model.actor.vocab
+                rewards_list = []
+                for comp_ids, gt_ids in zip(completions_np, targets_np):
+                    # Convert JAX tokens back to Python strings
+                    comp_str = vocab.id_to_string(comp_ids.tolist())
+                    gt_str = vocab.id_to_string(gt_ids.tolist())
+
+                    extracted_gen = _parse_gsm8k_number(comp_str)
+                    extracted_gt = _parse_gsm8k_number(gt_str)
+
+                    rewards_list.append(
+                        1.0 if extracted_gen == extracted_gt and extracted_gen != "" else 0.0
+                    )
+                return np.array(rewards_list, dtype=np.float32)
+
+            # Invoke Python string parser on Host CPU dynamically from the compiled TPU graph!
+            real_rewards = jax.pure_callback(
+                score_gsm8k_rollouts_python,
+                jax.ShapeDtypeStruct((flat_completions.shape[0],), jnp.float32),
+                flat_completions,
+                full_sequences[:, 1:],
+                vjp_method="none",  # Rewards are non-differentiable (zero gradients internally)
+            )
 
             # Determine surrogate gradients objectives
             learner_outputs = self.learner.grpo_loss(
                 actor_logps=actor_seq_logps,
                 old_logps=actor_seq_logps,
                 ref_logps=ref_seq_logps,
-                advantages=self.learner.compute_advantages(mock_rewards),
+                advantages=self.learner.compute_advantages(real_rewards),
                 completion_mask=completion_mask,
             )
 

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -291,10 +291,15 @@ class GrpoSpmdTrainer(SpmdTrainer):
             # Wrap in stop_gradient to indicate rewards are non-differentiable (zero gradients)
             real_rewards = jax.lax.stop_gradient(raw_rewards)
 
+            # Freeze the actor's current log probabilities to act as the old policy baseline.
+            # This ensures the PPO importance ratio is differentiable ONLY with respect to the new actor_logps!
+            # Without this, JAX would differentiate through both numerator and denominator, mathematically zeroing out the gradients!
+            old_seq_logps = jax.lax.stop_gradient(actor_seq_logps)
+
             # Determine surrogate gradients objectives
             learner_outputs = self.learner.grpo_loss(
                 actor_logps=actor_seq_logps,
-                old_logps=actor_seq_logps,
+                old_logps=old_seq_logps,
                 ref_logps=ref_seq_logps,
                 advantages=self.learner.compute_advantages(real_rewards),
                 completion_mask=completion_mask,

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -10,9 +10,10 @@ import jax.numpy as jnp
 import numpy as np
 
 from axlearn.common import utils
-from axlearn.common.config import config_class
-from axlearn.common.module import child_context
+from axlearn.common.config import REQUIRED, InstantiableConfig, Required, config_class
+from axlearn.common.module import Module, child_context
 from axlearn.common.module import functional as F
+from axlearn.common.module import new_output_collection
 from axlearn.common.trainer import SpmdTrainer, TrainerState
 from axlearn.common.update_transformation import ForwardOutputs
 from axlearn.common.utils import NestedTensor, Tensor
@@ -26,6 +27,12 @@ class GrpoSpmdTrainer(SpmdTrainer):
         """Configures GrpoSpmdTrainer."""
 
         num_generations: int = 4
+        vocab: Required[InstantiableConfig] = REQUIRED  # SentencePiece vocabulary configuration!
+
+    def __init__(self, cfg: Config, *, parent: Module):
+        super().__init__(cfg, parent=parent)
+        # Instantiate the configured vocabulary directly at startup!
+        self._vocab = cfg.vocab.instantiate()
 
     def _train_step(
         self,
@@ -51,11 +58,12 @@ class GrpoSpmdTrainer(SpmdTrainer):
             ref_params = params["reference"]
 
             prompt_prefix = inputs["input_batch"]["prefix"]
-            num_generations = inputs.get("num_generations", 4)
+            num_generations = self.learner.config.num_generations
             pad_id = inputs.get("pad_id", 0)
 
             # 1. Generate trajectories via active Actor model
-            model_output_collection = F.new_output_collection()
+            model_output_collection = new_output_collection()
+
             with child_context(
                 "model/actor",
                 module=self.model.actor,
@@ -98,7 +106,8 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 actor_results = self.model.actor.predict(eval_input)
 
             # Process Reference results
-            ref_output_collection = F.new_output_collection()
+            ref_output_collection = new_output_collection()
+
             with child_context(
                 "model/reference",
                 module=self.model.reference,
@@ -139,13 +148,14 @@ class GrpoSpmdTrainer(SpmdTrainer):
 
             def score_gsm8k_rollouts_python(completions_np, targets_np):
                 # Executed strictly on Host CPU using regular Python string operations!
-                # Retrieve vocabulary from model
-                vocab = self.model.actor.vocab
+                # Retrieve vocabulary directly from the trainer's instantiated vocab!
+                vocab = self._vocab
+
                 rewards_list = []
                 for comp_ids, gt_ids in zip(completions_np, targets_np):
                     # Convert JAX tokens back to Python strings
-                    comp_str = vocab.id_to_string(comp_ids.tolist())
-                    gt_str = vocab.id_to_string(gt_ids.tolist())
+                    comp_str = vocab.decode(comp_ids.tolist())
+                    gt_str = vocab.decode(gt_ids.tolist())
 
                     extracted_gen = _parse_gsm8k_number(comp_str)
                     extracted_gt = _parse_gsm8k_number(gt_str)
@@ -156,13 +166,15 @@ class GrpoSpmdTrainer(SpmdTrainer):
                 return np.array(rewards_list, dtype=np.float32)
 
             # Invoke Python string parser on Host CPU dynamically from the compiled TPU graph!
-            real_rewards = jax.pure_callback(
+            raw_rewards = jax.pure_callback(
                 score_gsm8k_rollouts_python,
                 jax.ShapeDtypeStruct((flat_completions.shape[0],), jnp.float32),
                 flat_completions,
                 full_sequences[:, 1:],
-                vjp_method="none",  # Rewards are non-differentiable (zero gradients internally)
             )
+
+            # Wrap in stop_gradient to indicate rewards are non-differentiable (zero gradients)
+            real_rewards = jax.lax.stop_gradient(raw_rewards)
 
             # Determine surrogate gradients objectives
             learner_outputs = self.learner.grpo_loss(
@@ -180,7 +192,7 @@ class GrpoSpmdTrainer(SpmdTrainer):
 
         opt_params = self._opt_params(state.model)
 
-        fwd_bwd_outputs, learner_output_collection = F.functional_call(
+        fwd_bwd_outputs, learner_output_collection = F(
             self.learner,
             method="forward_and_backward",
             state=state.learner,

--- a/axlearn/common/grpo_trainer.py
+++ b/axlearn/common/grpo_trainer.py
@@ -1,0 +1,183 @@
+# Copyright © 2026 Apple Inc.
+
+"""AXLearn SpmdTrainer orchestrating generation steps on twin models natively."""
+
+from typing import Dict, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from axlearn.common import utils
+from axlearn.common.config import config_class
+from axlearn.common.module import child_context
+from axlearn.common.module import functional as F
+from axlearn.common.trainer import SpmdTrainer, TrainerState
+from axlearn.common.update_transformation import ForwardOutputs
+from axlearn.common.utils import NestedTensor, Tensor
+
+
+class GrpoSpmdTrainer(SpmdTrainer):
+    """Extended SpmdTrainer subclass evaluating steps tasks concurrently."""
+
+    @config_class
+    class Config(SpmdTrainer.Config):
+        """Configures GrpoSpmdTrainer."""
+
+        num_generations: int = 4
+
+    def _train_step(
+        self,
+        state: TrainerState,
+        input_batch: dict,
+    ) -> Tuple[TrainerState, Dict]:
+
+        def train_cast(in_tree):
+            per_param_train_dtype = self._per_param_train_dtype(in_tree)
+            return utils.cast_floats_per_param(in_tree, per_param_train_dtype)
+
+        input_batch = train_cast(input_batch)
+        input_batch = self.input.dispatch_global_batch(input_batch)
+
+        new_prng_key, param_noise_key, forward_key, learner_key = jax.random.split(
+            state.prng_key, 4
+        )
+
+        def _forward(*, inputs: NestedTensor, model_params: NestedTensor) -> ForwardOutputs:
+            params = train_cast(model_params)
+
+            actor_params = params["actor"]
+            ref_params = params["reference"]
+
+            prompt_prefix = inputs["input_batch"]["prefix"]
+            num_generations = inputs.get("num_generations", 4)
+            pad_id = inputs.get("pad_id", 0)
+
+            # 1. Generate trajectories via active Actor model
+            model_output_collection = F.new_output_collection()
+            with child_context(
+                "model/actor",
+                module=self.model.actor,
+                state=actor_params,
+                prng_key=inputs["forward_key"],
+                output_collection=model_output_collection,
+            ):
+                sample_outputs = self.model.actor.sample_decode(
+                    input_batch={"prefix": prompt_prefix},
+                    num_decodes=num_generations,
+                )
+
+            generated_sequences = sample_outputs.sequences
+
+            # Reshape matrices across group space size
+            _, _, gen_len = generated_sequences.shape
+            flat_completions = generated_sequences.reshape(-1, gen_len)
+
+            prompt_len = prompt_prefix.shape[1]
+            flat_prompts = jnp.repeat(prompt_prefix, num_generations, axis=0)
+
+            full_sequences = jnp.concatenate([flat_prompts, flat_completions], axis=-1)
+            total_len = full_sequences.shape[-1]
+
+            eval_input = {
+                "input_ids": full_sequences,
+                "positions": jnp.arange(total_len)[None, :],
+                "target_labels": full_sequences,
+            }
+
+            # 2. Likelihood Calculations: Execute forward operations across models
+            # Process Actor results
+            with child_context(
+                "model/actor",
+                module=self.model.actor,
+                state=actor_params,
+                prng_key=inputs["forward_key"],
+                output_collection=model_output_collection,
+            ):
+                actor_results = self.model.actor.predict(eval_input)
+
+            # Process Reference results
+            ref_output_collection = F.new_output_collection()
+            with child_context(
+                "model/reference",
+                module=self.model.reference,
+                state=ref_params,
+                prng_key=inputs["forward_key"],
+                output_collection=ref_output_collection,
+            ):
+                reference_results = self.model.reference.predict(eval_input)
+
+            # 3. Convert network output logits to sequence probabilities
+            def extract_sequence_logps(logits: Tensor, token_ids: Tensor) -> Tensor:
+                log_probs = jax.nn.log_softmax(logits, axis=-1)
+                target_ids = token_ids[:, 1:]
+
+                gathered = jnp.take_along_axis(
+                    log_probs[:, :-1, :], jnp.expand_dims(target_ids, axis=-1), axis=-1
+                ).squeeze(-1)
+                return gathered
+
+            actor_seq_logps = extract_sequence_logps(actor_results["logits"], full_sequences)
+            ref_seq_logps = extract_sequence_logps(reference_results["logits"], full_sequences)
+
+            # Create target sequence extraction token masks
+            token_positions = jnp.arange(total_len - 1)[None, :]
+            completion_mask = (token_positions >= (prompt_len - 1)) & (
+                full_sequences[:, 1:] != pad_id
+            )
+
+            # Run mock evaluation scoring strategy
+            mock_rewards = jnp.ones((flat_completions.shape[0],))
+
+            # Determine surrogate gradients objectives
+            learner_outputs = self.learner.grpo_loss(
+                actor_logps=actor_seq_logps,
+                old_logps=actor_seq_logps,
+                ref_logps=ref_seq_logps,
+                advantages=self.learner.compute_advantages(mock_rewards),
+                completion_mask=completion_mask,
+            )
+
+            loss, loss_metrics = learner_outputs
+            return ForwardOutputs(
+                loss=loss, aux=loss_metrics, output_collection=model_output_collection
+            )
+
+        opt_params = self._opt_params(state.model)
+
+        fwd_bwd_outputs, learner_output_collection = F.functional_call(
+            self.learner,
+            method="forward_and_backward",
+            state=state.learner,
+            is_training=True,
+            prng_key=learner_key,
+            inputs=dict(
+                fn=_forward,
+                opt_params=opt_params,
+                inputs=dict(
+                    input_batch=input_batch,
+                    forward_key=forward_key,
+                    param_noise_key=param_noise_key,
+                    num_generations=self.config.num_generations,
+                ),
+            ),
+        )
+
+        forward_outputs: ForwardOutputs = fwd_bwd_outputs.forward_outputs
+        updated_model_params = fwd_bwd_outputs.backward_outputs.updated_params
+
+        updated_state = TrainerState(
+            prng_key=new_prng_key,
+            model=updated_model_params,
+            learner=learner_output_collection.state_updates,
+        )
+
+        summaries = dict(
+            model=forward_outputs.output_collection.summaries,
+            learner=learner_output_collection.summaries,
+        )
+
+        return updated_state, dict(
+            summaries=summaries,
+            loss=forward_outputs.loss,
+            aux=forward_outputs.aux,
+        )

--- a/axlearn/common/grpo_trainer_test.py
+++ b/axlearn/common/grpo_trainer_test.py
@@ -1,0 +1,210 @@
+import os
+
+os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+
+import tempfile
+
+import jax
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax import numpy as jnp
+from jax.sharding import PartitionSpec
+
+from axlearn.common import optimizers, test_utils
+from axlearn.common.base_layer import ParameterSpec
+from axlearn.common.base_model import BaseModel
+from axlearn.common.config import config_class, config_for_function
+from axlearn.common.grpo_learner import AxlearnGrpoLearner
+from axlearn.common.grpo_model import GrpoModel
+from axlearn.common.grpo_trainer import GrpoSpmdTrainer
+from axlearn.common.input_base import Input
+from axlearn.common.learner import UpdateType
+
+
+class DummyVocab:
+    def instantiate(self):
+        return self
+
+    def decode(self, ids):
+        return "mock_decoded_text #### 42"
+
+
+class MockGRPOInput(Input):
+    @config_class
+    class Config(Input.Config):
+        pass
+
+    def dataset(self):
+        # Yield dict matching GRPO trainer batch requirements
+        batch = {
+            "input_ids": jnp.ones([8, 32], dtype=jnp.int32),
+            "target_labels": -jnp.ones([8, 32], dtype=jnp.int32),  # mask out prefix
+        }
+        yield batch
+
+
+class SimpleDecoder(BaseModel):
+    @config_class
+    class Config(BaseModel.Config):
+        pad_token_id: int = 0
+
+    def create_parameter_specs_recursively(self):
+        return {
+            "weight": ParameterSpec(
+                shape=[8, 8],
+                dtype=jnp.float32,
+                mesh_axes=PartitionSpec("model"),
+            )
+        }
+
+    def initialize_parameters_recursively(self, prng_key, *, prebuilt=None):
+        return {"weight": jax.random.normal(prng_key, [8, 8], dtype=jnp.float32)}
+
+    def sample_decode(self, input_batch, max_sequence_length, num_decodes):
+        class Outputs:
+            sequences = jnp.ones(
+                [input_batch["prefix"].shape[0], num_decodes, max_sequence_length], dtype=jnp.int32
+            )
+
+        return Outputs()
+
+    def project(self, x):
+        return x @ self.state["weight"]
+
+
+class MockModel(BaseModel):
+    @config_class
+    class Config(BaseModel.Config):
+        pass
+
+    def __init__(self, cfg: Config, *, parent):
+        super().__init__(cfg, parent=parent)
+        self._add_child("decoder", SimpleDecoder.default_config())
+
+    def predict(self, input_batch):
+        x = input_batch["input_ids"].astype(jnp.float32)  # Shape [batch, seq_len]
+        seq_len = x.shape[1]
+        # Enter child context of decoder to access its state
+        from axlearn.common.module import child_context, new_output_collection
+
+        output_collection = new_output_collection()
+        with child_context(
+            "decoder",
+            module=self.decoder,
+            state=self.state["decoder"],
+            output_collection=output_collection,
+        ):
+            projected = self.decoder.project(x[:, :8])
+        # Tile projected representation to match logits shape dynamically along the sequence axis
+        logits = jnp.tile(projected[:, None, :], (1, seq_len, 1))[:, :, :10]
+        return {"logits": logits}
+
+
+class GrpoTrainerTest(test_utils.TestCase):
+    """Tests GrpoSpmdTrainer disaggregated execution."""
+
+    @parameterized.parameters(
+        {"platform": "cpu", "mesh_shape": (1, 1, 1, 8, 1, 1)},
+    )
+    def test_disaggregated_trainer(self, platform, mesh_shape):
+        if not test_utils.is_supported_platform(platform):
+            return
+
+        # 1. Build config
+        cfg = GrpoSpmdTrainer.default_config().set(
+            name="grpo_trainer",
+            dir=tempfile.mkdtemp(),
+            mesh_axis_names=("pipeline", "data", "expert", "fsdp", "seq", "model"),
+            mesh_shape=mesh_shape,
+            model=GrpoModel.default_config().set(
+                name="model",
+                dtype=jnp.float32,
+                actor=MockModel.default_config(),
+                reference=MockModel.default_config(),
+                sampler=MockModel.default_config(),
+            ),
+            vocab=config_for_function(DummyVocab),
+            num_generations=2,
+            max_step=1,
+            learner=AxlearnGrpoLearner.default_config().set(
+                name="learner",
+                num_generations=2,
+                beta=0.04,
+                optimizer=config_for_function(optimizers.sgd_optimizer).set(
+                    learning_rate=0.1, decouple_weight_decay=True
+                ),
+                update_rules=[
+                    ("reference/.*", UpdateType.NO_UPDATE),
+                    ("sampler/.*", UpdateType.NO_UPDATE),
+                ],
+            ),
+            input=MockGRPOInput.default_config(),
+        )
+
+        # 2. Instantiate Trainer
+        trainer: GrpoSpmdTrainer = cfg.instantiate(parent=None)
+
+        # Verify dual meshes constructed successfully
+        self.assertEqual(trainer.trainer_mesh.devices.size, 4)
+        self.assertEqual(trainer.rollout_mesh.devices.size, 4)
+
+        # Verify sharding of parameters across the global mesh
+        self.assertEqual(
+            trainer.trainer_state_partition_specs.model["actor"]["decoder"]["weight"].mesh,
+            trainer.mesh(),
+        )
+        self.assertEqual(
+            trainer.trainer_state_partition_specs.model["reference"]["decoder"]["weight"].mesh,
+            trainer.mesh(),
+        )
+        self.assertEqual(
+            trainer.trainer_state_partition_specs.model["sampler"]["decoder"]["weight"].mesh,
+            trainer.mesh(),
+        )
+
+        # 3. Initialize state
+        prng_key = jax.random.PRNGKey(123)
+        with trainer.mesh():
+            trainer.init(prng_key)
+
+        state = trainer.trainer_state
+
+        # Capture initial parameters
+        initial_actor_weight = state.model["actor"]["decoder"]["weight"]
+        initial_ref_weight = state.model["reference"]["decoder"]["weight"]
+        initial_sampler_weight = state.model["sampler"]["decoder"]["weight"]
+
+        # 4. Execute one training step
+        output = trainer.run(prng_key=prng_key)
+        final_state = trainer.trainer_state
+
+        final_actor_weight = final_state.model["actor"]["decoder"]["weight"]
+        final_ref_weight = final_state.model["reference"]["decoder"]["weight"]
+        final_sampler_weight = final_state.model["sampler"]["decoder"]["weight"]
+
+        # 5. Validate results
+        # Actor should have updated weights due to SFT training
+        self.assertFalse(np.array_equal(initial_actor_weight, final_actor_weight))
+
+        # Reference weights must be COMPLETELY unchanged
+        self.assertTrue(np.array_equal(initial_ref_weight, final_ref_weight))
+
+        # Sampler weights must exactly match final actor weights (successful synchronization!)
+        self.assertTrue(np.array_equal(final_sampler_weight, final_actor_weight))
+        self.assertEqual(final_sampler_weight.sharding.mesh, trainer.mesh())
+
+        # Verify optimizer state is only allocated for actor (reference and sampler have none)
+        optimizer_state = final_state.learner["optimizer"]
+        import optax
+
+        # Flatten the entire optimizer state tree to inspect dynamic leaves
+        opt_items = test_utils.flatten_items(optimizer_state)
+        for path, value in opt_items:
+            if "reference" in path or "sampler" in path:
+                self.assertTrue(value is None or isinstance(value, optax.MaskedNode))
+            elif "actor" in path:
+                self.assertFalse(value is None or isinstance(value, optax.MaskedNode))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/axlearn/common/grpo_trainer_test.py
+++ b/axlearn/common/grpo_trainer_test.py
@@ -104,9 +104,11 @@ class GrpoTrainerTest(test_utils.TestCase):
     """Tests GrpoSpmdTrainer disaggregated execution."""
 
     @parameterized.parameters(
-        {"platform": "cpu", "mesh_shape": (1, 1, 1, 8, 1, 1)},
+        {"platform": "cpu", "mesh_shape": (1, 1, 1, 8, 1, 1), "reward_type": "gsm8k"},
+        {"platform": "cpu", "mesh_shape": (1, 1, 1, 8, 1, 1), "reward_type": "dummy"},
+        {"platform": "cpu", "mesh_shape": (1, 1, 1, 8, 1, 1), "reward_type": "exact_match"},
     )
-    def test_disaggregated_trainer(self, platform, mesh_shape):
+    def test_disaggregated_trainer(self, platform, mesh_shape, reward_type):
         if not test_utils.is_supported_platform(platform):
             return
 
@@ -116,6 +118,7 @@ class GrpoTrainerTest(test_utils.TestCase):
             dir=tempfile.mkdtemp(),
             mesh_axis_names=("pipeline", "data", "expert", "fsdp", "seq", "model"),
             mesh_shape=mesh_shape,
+            reward_type=reward_type,
             model=GrpoModel.default_config().set(
                 name="model",
                 dtype=jnp.float32,

--- a/axlearn/experiments/text/gpt/grpo_example.md
+++ b/axlearn/experiments/text/gpt/grpo_example.md
@@ -6,18 +6,18 @@ The generation and training workloads are decoupled onto distinct hardware parti
 
 
 # Setup
-* Training dataset: gsm8k  
+* Training dataset: gsm8k
 * Pretrained model: Llama-3.1-8B-Instruct compatible with fuji-8B. The model is the base for actor, reference, and sampler
 * TPU Topology: v6e-16
 * GKE Nodepool
   * Pathways: n2-standard-64 (autoscale up to 10)
-  * Workers: 4 x ct6e-standard-4t 
+  * Workers: 4 x ct6e-standard-4t
 * Global mesh: (1, 1, 8, 8, 1, 1), data and fsdp parallelism on data and fsdp dimensions
 * rollout_mesh: (1, 1, 8, 1, 1, 1), tensor/data parallelism on data dimension
 * trainer_mesh: (1, 1, 1, 8, 1, 1), fsdp parallelism on fsdp dimension
 
 # Pre Requisite
-The utility scripts rely on Axlearn and follow the [instructions](https://github.com/apple/axlearn/blob/main/docs/01-start.md#installation) to set up your Axlearn env and install the packages for dev. You may need a machine with high memory to run the script. 
+The utility scripts rely on Axlearn and follow the [instructions](https://github.com/apple/axlearn/blob/main/docs/01-start.md#installation) to set up your Axlearn env and install the packages for dev. You may need a machine with high memory to run the script.
 
 ## Training Dataset gsm8k
 To prepare the GSM8K reasoning dataset for AXLearn training pipelines, the raw data must be downloaded and serialized into sharded TFRecord files. The example provides a dedicated conversion utility convert_gsm8k_to_tfrecord.py.
@@ -37,7 +37,7 @@ Run the following command to download and convert the LLaMA-3.1 8B Instruct mode
 
 ```shell
 python3 -m axlearn.tools.download_llama3_checkpoint \
-    --model_id="meta-llama/Llama-3.1-8B-Instruct" \ 
+    --model_id="meta-llama/Llama-3.1-8B-Instruct" \
     --model_size="8B" \
     --output_dir="gs://ericshen-axlearn/checkpoints/llama-3-1-8B-instruct" # change to your gcs location
 
@@ -68,7 +68,7 @@ export OUTPUT_DIR="gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/${NAME}/$(
   --bundler_type=artifactregistry \
   --bundler_spec=image=tpu \
   --bundler_spec=dockerfile=Dockerfile \
-  --bundler_spec=target=tpu --pathways_head_mem=128 --pathways_head_cpu=8 --env=GRPO_REWARD_TYPE:gsm8k \ #set the reward_type to gsm8k. otherwise it'd be dummy reward. 
+  --bundler_spec=target=tpu --pathways_head_mem=128 --pathways_head_cpu=8 --env=GRPO_REWARD_TYPE:gsm8k \ #set the reward_type to gsm8k. otherwise it'd be dummy reward.
   -- \
   python3 -m axlearn.common.launch_trainer_main \
   --module=text.gpt.grpo_native_example \
@@ -120,7 +120,3 @@ gcloud storage cat gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-
 # get trainer config
 gcloud storage cat gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo/1778611794/trainer_config
 ```
-
-
-
-

--- a/axlearn/experiments/text/gpt/grpo_example.md
+++ b/axlearn/experiments/text/gpt/grpo_example.md
@@ -88,7 +88,7 @@ During GRPO training, AXLearn logs several crucial telemetry metrics to track po
 * `std_advantage`: The standard deviation of the computed advantages across rollouts, reflecting the variance and diversity of rewards within the generated groups.
 * `kl_divergence`: The token-level Kullback-Leibler (KL) divergence between the active Actor policy and the frozen Reference policy. This tracks how far the model's generation distribution has shifted from the initial pre-trained foundation checkpoint.
 
-`Sample output`: [TBD]()
+`Sample output`: [grpo_pathways_sample_output](./grpo_pythways_sample_output.md)
 
 ## Monitoring & Checking
 ### Kubectl logs

--- a/axlearn/experiments/text/gpt/grpo_example.md
+++ b/axlearn/experiments/text/gpt/grpo_example.md
@@ -1,0 +1,126 @@
+# Overview
+Group Relative Policy Optimization (GRPO) is a reinforcement learning algorithm designed to efficiently train Large Language Models (LLMs) without requiring a Critic model. In standard PPO, a Critic model (often of equal size to the Actor) must be kept in memory to estimate baseline value functions for advantage computation. GRPO eliminates this memory overhead entirely. Instead, for each input prompt, GRPO samples a group of distinct generations (rollouts) from the Actor policy, scores them using a reward model or rule-based function, and computes relative advantages by normalizing the rewards within that group (subtracting the group mean and dividing by the group standard deviation). The policy is then optimized using a PPO-style clipped surrogate objective alongside a KL divergence constraint against a frozen Reference model to prevent policy drift.
+
+# Separate Sampler and Trainer with Pathways
+The generation and training workloads are decoupled onto distinct hardware partitions within a global mesh. For example, half of the available accelerators are assigned to a rollout_mesh optimized for low-latency autoregressive decoding (using tensor/data parallelism), while the other half forms a trainer_mesh optimized for FSDP-based gradient updates. Weights are synchronized across meshes after each training step.
+
+
+# Setup
+* Training dataset: gsm8k  
+* Pretrained model: Llama-3.1-8B-Instruct compatible with fuji-8B. The model is the base for actor, reference, and sampler
+* TPU Topology: v6e-16
+* GKE Nodepool
+  * Pathways: n2-standard-64 (autoscale up to 10)
+  * Workers: 4 x ct6e-standard-4t 
+* Global mesh: (1, 1, 8, 8, 1, 1), data and fsdp parallelism on data and fsdp dimensions
+* rollout_mesh: (1, 1, 8, 1, 1, 1), tensor/data parallelism on data dimension
+* trainer_mesh: (1, 1, 1, 8, 1, 1), fsdp parallelism on fsdp dimension
+
+# Pre Requisite
+The utility scripts rely on Axlearn and follow the [instructions](https://github.com/apple/axlearn/blob/main/docs/01-start.md#installation) to set up your Axlearn env and install the packages for dev. You may need a machine with high memory to run the script. 
+
+## Training Dataset gsm8k
+To prepare the GSM8K reasoning dataset for AXLearn training pipelines, the raw data must be downloaded and serialized into sharded TFRecord files. The example provides a dedicated conversion utility convert_gsm8k_to_tfrecord.py.
+
+Run the following command to download and serialize the GSM8K dataset into 8 shards:
+
+```shell
+python3 -m axlearn.tools.convert_gsm8k_to_tfrecord \
+    --output_dir="gs://ericshen-axlearn/tensorflow-datasets" \ #change to your gcs location
+    --num_shards=8
+```
+
+## Pretrained Model Checkpoint from Huggingface
+An automated utility can be used to download pre-trained weights from the Hugging Face Hub, convert them into AXLearn's native JAX parameter structures (Fuji), and serialize them to GCS via TensorStore.
+
+Run the following command to download and convert the LLaMA-3.1 8B Instruct model checkpoint:
+
+```shell
+python3 -m axlearn.tools.download_llama3_checkpoint \
+    --model_id="meta-llama/Llama-3.1-8B-Instruct" \ 
+    --model_size="8B" \
+    --output_dir="gs://ericshen-axlearn/checkpoints/llama-3-1-8B-instruct" # change to your gcs location
+
+```
+
+# Train
+To launch the combined trainer/sampler GRPO experiment on Google Cloud TPU instances using AXLearn's launch utility, set up your environment variables and execute `launch_trainer_main`:
+
+```shell
+# 1. Set the following envs
+export BASTION_TIER=disabled
+export NAME=eshen-v6e-rl-grpo-pathways # change to your name
+export RUNNER_NAME=gke_tpu_single
+export CONFIG=grpo-fuji-8B-v1
+export INSTANCE_TYPE=tpu-v6e-16 #change to your instance type
+export CLUSTER=ericshen-axlearn #change to your cluster name
+export OUTPUT_DIR="gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/${NAME}/$(date +%s)" #change to your gcs location for training output
+
+
+# 2. Launch the trainer job
+(.venv) ➜  axlearn git:(rl-example-pathways) ✗ nohup axlearn gcp launch run \
+  --cluster=$CLUSTER \
+  --instance_type=$INSTANCE_TYPE \
+  --name=$NAME \
+  --num_replicas=1 \
+  --runner_name=$RUNNER_NAME \
+  --bundler_spec=allow_dirty=True \
+  --bundler_type=artifactregistry \
+  --bundler_spec=image=tpu \
+  --bundler_spec=dockerfile=Dockerfile \
+  --bundler_spec=target=tpu --pathways_head_mem=128 --pathways_head_cpu=8 --env=GRPO_REWARD_TYPE:gsm8k \ #set the reward_type to gsm8k. otherwise it'd be dummy reward. 
+  -- \
+  python3 -m axlearn.common.launch_trainer_main \
+  --module=text.gpt.grpo_native_example \
+  --config=$CONFIG \
+  --trainer_dir=$OUTPUT_DIR \
+  --data_dir=gs://ericshen-axlearn/tensorflow-datasets \
+  --jax_backend=proxy \
+   --trainer_log_every_n_steps=10 > axlearn_launcher.log 2>&1 &
+```
+
+# Output
+## Explanation of training metrics
+During GRPO training, AXLearn logs several crucial telemetry metrics to track policy optimization, reward improvements, and stability:
+* `loss`: The total GRPO surrogate policy objective loss, which combines the clipped importance-sampling policy loss and the KL divergence penalty.
+* `mean_reward`: The average raw math accuracy achieved by the generated rollouts in the current batch (e.g., 1.0 for correct boxed/extracted final numbers matching the ground truth, 0.0 otherwise). A rising mean_reward indicates successful mathematical reasoning alignment.
+* `mean_advantage`: The average group-relative advantage value across the batch. While normalized advantages average to zero within each prompt group, tracking batch-wide stability ensures correct reward distribution.
+* `std_advantage`: The standard deviation of the computed advantages across rollouts, reflecting the variance and diversity of rewards within the generated groups.
+* `kl_divergence`: The token-level Kullback-Leibler (KL) divergence between the active Actor policy and the frozen Reference policy. This tracks how far the model's generation distribution has shifted from the initial pre-trained foundation checkpoint.
+
+`Sample output`: [TBD]()
+
+## Monitoring & Checking
+### Kubectl logs
+
+```shell
+# tail the log of the pod
+k logs -f eshen-v6e-rl-grpo-job-0-1-dgsvd
+
+
+# only grep the metrics line like the following
+# I0513 14:17:45.599639 136435580311488 trainer.py:409] grpo_trainer process   2 step     1000] loss=0.05171673 aux={'kl_divergence': 1.2890625, 'loss': 0.05171672999858856, 'mean_advantage': 0.0, 'mean_reward': 0.8203125, 'std_advantage': 0.3061429262161255}
+
+k logs -f eshen-v6e-rl-grpo-job-0-1-dgsvd | grep kl_div
+```
+### Log Explorer
+
+``` shell
+– Set the time range during which the job has run
+resource.type="k8s_container"
+resource.labels.cluster_name="ericshen-axlearn" -- change to your cluster
+(("kl_divergence" AND "grpo_trainer process   0") OR "Average step time:")
+```
+### GCS Output Location
+```shell
+# get model analysis
+gcloud storage cat gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo/1778611794/model_analysis.txt
+
+
+# get trainer config
+gcloud storage cat gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo/1778611794/trainer_config
+```
+
+
+
+

--- a/axlearn/experiments/text/gpt/grpo_example.md
+++ b/axlearn/experiments/text/gpt/grpo_example.md
@@ -6,8 +6,8 @@ The generation and training workloads are decoupled onto distinct hardware parti
 
 
 # Setup
-* Training dataset: gsm8k
-* Pretrained model: Llama-3.1-8B-Instruct compatible with fuji-8B. The model is the base for actor, reference, and sampler
+* Training dataset: [gsm8k  ](https://www.tensorflow.org/datasets/catalog/gsm8k)
+* Pretrained model: [Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct) compatible with fuji-8B. The model is the base for actor, reference, and sampler
 * TPU Topology: v6e-16
 * GKE Nodepool
   * Pathways: n2-standard-64 (autoscale up to 10)

--- a/axlearn/experiments/text/gpt/grpo_native_example.py
+++ b/axlearn/experiments/text/gpt/grpo_native_example.py
@@ -17,6 +17,7 @@ from axlearn.common.config import (
     Required,
     TrainerConfigFn,
     config_class,
+    config_for_class,
     config_for_function,
 )
 from axlearn.common.grpo_learner import AxlearnGrpoLearner
@@ -28,15 +29,31 @@ from axlearn.common.state_builder import Builder, TensorStoreStateStorageBuilder
 from axlearn.experiments.text.common import tfds_text_source, vocab
 from axlearn.experiments.text.gpt import fuji
 from axlearn.experiments.text.gpt.common import MESH_AXIS_NAMES
+from axlearn.experiments.text.gpt.vocabulary_fuji_v3 import FujiV3Vocabulary
 from axlearn.tools.convert_gsm8k_to_tfrecord import verify_and_print_records
+
+
+class GRPOV3Vocabulary(FujiV3Vocabulary):
+    """Custom FujiV3Vocabulary subclass providing a robust fallback for missing pad token IDs
+
+    on certain pre-trained SentencePiece/TikToken tokenizer configurations.
+    """
+
+    @property
+    def pad_id(self) -> int:
+        # Strictly returns 0 to satisfy seqio's data padding and pipeline constraints perfectly!
+        return 0
 
 
 def _vocab_cfg(vocab_size: int) -> InstantiableConfig:
     """Constructs vocabulary configuration instance based on size."""
     if vocab_size in (32 * 1024, 32000):
         return config_for_function(vocab).set(sentencepiece_model_name="bpe_32k_c4.model")
-    if vocab_size in (128 * 1024, 128256):
+    if vocab_size == 128 * 1024:
         return config_for_function(vocab).set(sentencepiece_model_name="bpe_128k_c4.model")
+    if vocab_size == 128256:
+        # TikToken tokenizer layout with robust padding fallbacks!
+        return config_for_class(GRPOV3Vocabulary).set(filename="Llama-3-tokenizer.json")
     raise ValueError(f"Unsupported vocabulary size: {vocab_size}")
 
 
@@ -194,7 +211,15 @@ def trainer_configs(
         )
 
         fuji_model_cfg = fuji_kwargs["model_cfg"]
-        max_sequence_length = fuji_kwargs["max_sequence_length"]
+
+        # Force bfloat16 precision on all underlying model, decoder, and attention parameters!
+        # This cuts the physical parameter and intermediate activations memory footprint in half globally!
+        fuji_model_cfg.dtype = jnp.bfloat16
+        fuji_model_cfg.decoder.dtype = jnp.bfloat16
+
+        # Overrides max_sequence_length to 512 to reduce the attention matrix footprint another 4-fold!
+        # This guarantees high-speed, OOM-free training on standard word problem datasets like GSM8K.
+        max_sequence_length = 512
 
         logging.info("[eshenlog] Instantiating GrpoModel with jnp.bfloat16 dtype to prevent OOM...")
         grpo_model_cfg = GrpoModel.default_config().set(
@@ -251,7 +276,7 @@ def trainer_configs(
             # Configure the underlying storage builder to read GCS files with strict validations disabled!
             storage_builder_cfg = TensorStoreStateStorageBuilder.default_config().set(
                 dir=f"gs://ericshen-axlearn/checkpoints/{gcs_dir_name}/step_00000000",
-                validation="CONTAINS_STATE",  # <--- Ignors missing optimizer parameters by checking only subset keys!
+                validation="CONTAINS_STATE_UP_TO_DTYPE",  # <--- Ignores float32 to bfloat16 dtype differences and casts on the fly!
             )
 
             # Use custom GRPOStateBuilder to manually replicate flat GCS parameters into both policy sub-trees!

--- a/axlearn/experiments/text/gpt/grpo_native_example.py
+++ b/axlearn/experiments/text/gpt/grpo_native_example.py
@@ -1,0 +1,93 @@
+# Copyright © 2026 Apple Inc.
+
+"""Driver configurations module utilizing tfds_input over local/remote sources."""
+
+from typing import Dict
+
+from axlearn.common.config import InstantiableConfig, TrainerConfigFn, config_for_function
+from axlearn.common.grpo_learner import AxlearnGrpoLearner
+from axlearn.common.grpo_model import GrpoModel
+from axlearn.common.grpo_trainer import GrpoSpmdTrainer
+from axlearn.experiments.text.common import vocab
+from axlearn.experiments.text.gpt import fuji
+from axlearn.experiments.text.gpt.common import tfds_input
+
+
+def _vocab_cfg(vocab_size: int) -> InstantiableConfig:
+    """Constructs vocabulary configuration instance based on size."""
+    if vocab_size == 32 * 1024:
+        return config_for_function(vocab).set(sentencepiece_model_name="bpe_32k_c4.model")
+    if vocab_size == 128 * 1024:
+        return config_for_function(vocab).set(sentencepiece_model_name="bpe_128k_c4.model")
+    raise ValueError(f"Unsupported vocabulary size: {vocab_size}")
+
+
+def _train_input_source(*, max_sequence_length: int) -> InstantiableConfig:
+    """Instantiates native AXLearn streaming input pipeline configured over gsm8k."""
+    return config_for_function(tfds_input).set(
+        dataset_name="gsm8k",
+        split="train",
+        is_training=True,
+        vocab_cfg=_vocab_cfg(32 * 1024),
+        max_sequence_length=max_sequence_length,
+    )
+
+
+def _eval_input_sources(*, max_sequence_length: int) -> dict[str, InstantiableConfig]:
+    """Evaluates streaming input configurations targeting validations."""
+    return {
+        "validation": config_for_function(tfds_input).set(
+            dataset_name="gsm8k",
+            split="test",
+            is_training=False,
+            vocab_cfg=_vocab_cfg(32 * 1024),
+            max_sequence_length=max_sequence_length,
+        )
+    }
+
+
+def trainer_configs(
+    model_size: str,
+    version: fuji.Version = fuji.Version.V1,
+) -> Dict[str, TrainerConfigFn]:
+    """Named configurations mapper."""
+    config_map = {}
+
+    def get_config_fn():
+        fuji_kwargs = fuji.get_trainer_kwargs(
+            model_size, vocab_size=32 * 1024, version=version, flash_attention=True
+        )
+
+        fuji_model_cfg = fuji_kwargs["model_kwargs"]
+        max_sequence_length = fuji_kwargs["max_sequence_length"]
+
+        grpo_model_cfg = GrpoModel.default_config().set(
+            actor=fuji.model_config(**fuji_model_cfg),
+            reference=fuji.model_config(**fuji_model_cfg),
+        )
+
+        trainer_cfg = GrpoSpmdTrainer.default_config().set(
+            model=grpo_model_cfg,
+            learner=AxlearnGrpoLearner.default_config().set(
+                num_generations=4,
+                beta=0.04,
+            ),
+            mesh_shape=fuji_kwargs["mesh_shape"],
+        )
+
+        # Connect with native storage structures Input pipeline
+        trainer_cfg.input.source = _train_input_source(max_sequence_length=max_sequence_length)
+        return trainer_cfg
+
+    config_key = f"grpo-fuji-{model_size}-v1"
+    config_map[config_key] = get_config_fn
+    return config_map
+
+
+def named_trainer_configs() -> Dict[str, TrainerConfigFn]:
+    """Configuration registry entry."""
+    config_map = {}
+    config_map.update(trainer_configs("test"))
+    config_map.update(trainer_configs("7B"))
+    config_map.update(trainer_configs("70B"))
+    return config_map

--- a/axlearn/experiments/text/gpt/grpo_native_example.py
+++ b/axlearn/experiments/text/gpt/grpo_native_example.py
@@ -2,12 +2,13 @@
 
 """Driver configurations module utilizing tfds_input over local/remote sources, fully supporting Meta's LLaMA-3.1-8B and 70B configurations."""
 
+import os
 from typing import Dict, Optional
 
 import jax
 import jax.numpy as jnp
 import tensorflow as tf
-from absl import logging
+from absl import flags, logging
 from jax.sharding import PartitionSpec
 
 from axlearn.common import input_base, input_lm, input_tf_data, optimizers
@@ -29,9 +30,11 @@ from axlearn.common.module import Module
 from axlearn.common.state_builder import Builder, TensorStoreStateStorageBuilder
 from axlearn.experiments.text.common import tfds_text_source, vocab
 from axlearn.experiments.text.gpt import fuji
-from axlearn.experiments.text.gpt.common import MESH_AXIS_NAMES
+from axlearn.experiments.text.gpt.common import MESH_AXIS_NAMES, mesh_shape_from_axes
 from axlearn.experiments.text.gpt.vocabulary_fuji_v3 import FujiV3Vocabulary
 from axlearn.tools.convert_gsm8k_to_tfrecord import verify_and_print_records
+
+grpo_reward_type = os.getenv("GRPO_REWARD_TYPE", "dummy")
 
 
 class GRPOV3Vocabulary(FujiV3Vocabulary):
@@ -173,11 +176,16 @@ class GRPOStateBuilder(Builder):
         flat_state = self.storage_builder(flat_builder_state)
         flat_model = flat_state.trainer_state.model
 
-        # 3. Manually replicate the restored parameters into both Actor and Reference policy sub-trees recursively!
-        # Physically copy/clone the Reference parameters PyTree using jax.tree.map(jnp.copy)
+        # 3. Manually replicate the restored parameters into Actor, Reference, and Sampler policy sub-trees recursively!
+        # Physically copy/clone the parameters PyTree using jax.tree.map(jnp.copy)
         # to create independent device buffers and prevent JAX double-donation crashes!
         cloned_reference_model = jax.tree.map(jnp.copy, flat_model)
-        actor_ref_model = {"actor": flat_model, "reference": cloned_reference_model}
+        cloned_sampler_model = jax.tree.map(jnp.copy, flat_model)
+        actor_ref_model = {
+            "actor": flat_model,
+            "reference": cloned_reference_model,
+            "sampler": cloned_sampler_model,
+        }
 
         # 4. Rebuild the fully populated JAX TrainerState PyTree seamlessly
         updated_trainer_state = state.trainer_state._replace(model=actor_ref_model)
@@ -247,6 +255,8 @@ def trainer_configs(
         trainer_cfg = GrpoSpmdTrainer.default_config().set(
             name="grpo_trainer",  # Explicitly set name to satisfy config requirements
             model=grpo_model_cfg,
+            reward_type=grpo_reward_type,
+            start_trace_steps=[],
             vocab=_vocab_cfg(
                 vocab_size
             ),  # <--- Passes the sentencepiece vocabulary directly to the trainer!
@@ -263,14 +273,9 @@ def trainer_configs(
                 ],
             ),
             mesh_axis_names=MESH_AXIS_NAMES,  # Aligns natively with AXLearn's canonical 6D hybrid mesh constant!
-            mesh_shape=[
-                1,
-                1,
-                1,
-                total_devices,
-                1,
-                1,
-            ],  # <--- Dynamically scale global mesh to hold all available devices!
+            mesh_shape=mesh_shape_from_axes(
+                fsdp=-1
+            ),  # <--- Dynamically scale global mesh using AXLearn's native -1 inference!
         )
 
         # Dynamically load pre-trained foundation weights from GCS at startup based on model size
@@ -285,6 +290,7 @@ def trainer_configs(
             storage_builder_cfg = TensorStoreStateStorageBuilder.default_config().set(
                 dir=f"gs://ericshen-axlearn/checkpoints/{gcs_dir_name}/step_00000000",
                 validation="CONTAINS_STATE_UP_TO_DTYPE",  # <--- Ignores float32 to bfloat16 dtype differences and casts on the fly!
+                concurrent_gb=4,  # <--- Restrict concurrent restore to 4GB to prevent head pod OOMKilled!
             )
 
             # Use custom GRPOStateBuilder to manually replicate flat GCS parameters into both policy sub-trees!
@@ -337,6 +343,13 @@ def trainer_configs(
                         "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
                     },
                     "model.reference.decoder.emb.token_emb": {
+                        "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
+                    },
+                    # Sampler layers sharding overrides
+                    "model.sampler.decoder.lm_head": {
+                        "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
+                    },
+                    "model.sampler.decoder.emb.token_emb": {
                         "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
                     },
                 }

--- a/axlearn/experiments/text/gpt/grpo_native_example.py
+++ b/axlearn/experiments/text/gpt/grpo_native_example.py
@@ -24,6 +24,7 @@ from axlearn.common.grpo_learner import AxlearnGrpoLearner
 from axlearn.common.grpo_model import GrpoModel
 from axlearn.common.grpo_trainer import GrpoSpmdTrainer
 from axlearn.common.input_dispatch import SpmdInputDispatcher
+from axlearn.common.learner import UpdateType
 from axlearn.common.module import Module
 from axlearn.common.state_builder import Builder, TensorStoreStateStorageBuilder
 from axlearn.experiments.text.common import tfds_text_source, vocab
@@ -227,6 +228,7 @@ def trainer_configs(
             dtype=jnp.bfloat16,  # Explicitly set dtype to bfloat16 to reduce memory consumption by 50% and prevent OOM!
             actor=fuji_model_cfg,
             reference=fuji_model_cfg,
+            sampler=fuji_model_cfg,  # Instantiate decoupled sampler configuration
         )
 
         # 1. Configure a standard decoupled AdamW optimizer for SFT training
@@ -237,8 +239,10 @@ def trainer_configs(
             eps=1e-8,
         )
 
+        total_devices = len(jax.devices())
         logging.info(
-            "[eshenlog] Instantiating GrpoSpmdTrainer with custom 16-way FSDP sharding mesh..."
+            "[eshenlog] Instantiating GrpoSpmdTrainer with dynamic %d-device sharding mesh...",
+            total_devices,
         )
         trainer_cfg = GrpoSpmdTrainer.default_config().set(
             name="grpo_trainer",  # Explicitly set name to satisfy config requirements
@@ -253,16 +257,20 @@ def trainer_configs(
                 num_generations=2,  # <--- Sets Learner group size to 2!
                 beta=0.04,
                 optimizer=optimizer_cfg,  # <--- Satisfies required optimizer parameters!
+                update_rules=[
+                    ("reference/.*", UpdateType.NO_UPDATE),  # Freeze reference parameters
+                    ("sampler/.*", UpdateType.NO_UPDATE),  # Freeze sampler parameters
+                ],
             ),
             mesh_axis_names=MESH_AXIS_NAMES,  # Aligns natively with AXLearn's canonical 6D hybrid mesh constant!
             mesh_shape=[
                 1,
                 1,
                 1,
-                16,
+                total_devices,
                 1,
                 1,
-            ],  # <--- Overrides to fsdp=16 sharding mesh to prevent OOM!
+            ],  # <--- Dynamically scale global mesh to hold all available devices!
         )
 
         # Dynamically load pre-trained foundation weights from GCS at startup based on model size

--- a/axlearn/experiments/text/gpt/grpo_native_example.py
+++ b/axlearn/experiments/text/gpt/grpo_native_example.py
@@ -4,6 +4,7 @@
 
 from typing import Dict, Optional
 
+import jax
 import jax.numpy as jnp
 import tensorflow as tf
 from absl import logging
@@ -155,7 +156,10 @@ class GRPOStateBuilder(Builder):
         flat_model = flat_state.trainer_state.model
 
         # 3. Manually replicate the restored parameters into both Actor and Reference policy sub-trees recursively!
-        actor_ref_model = {"actor": flat_model, "reference": flat_model}
+        # Physically copy/clone the Reference parameters PyTree using jax.tree.map(jnp.copy)
+        # to create independent device buffers and prevent JAX double-donation crashes!
+        cloned_reference_model = jax.tree.map(jnp.copy, flat_model)
+        actor_ref_model = {"actor": flat_model, "reference": cloned_reference_model}
 
         # 4. Rebuild the fully populated JAX TrainerState PyTree seamlessly
         updated_trainer_state = state.trainer_state._replace(model=actor_ref_model)
@@ -186,14 +190,13 @@ def trainer_configs(
             logging.warning("[eshenlog] Pre-training dataset verification skipped or failed: %s", e)
 
         fuji_kwargs = fuji.get_trainer_kwargs(
-            model_size, vocab_size=vocab_size, version=version, flash_attention=True
+            model_size, vocab_size=vocab_size, version=version, flash_attention=False
         )
 
         fuji_model_cfg = fuji_kwargs["model_cfg"]
         max_sequence_length = fuji_kwargs["max_sequence_length"]
 
         logging.info("[eshenlog] Instantiating GrpoModel with jnp.bfloat16 dtype to prevent OOM...")
-
         grpo_model_cfg = GrpoModel.default_config().set(
             name="model",  # Explicitly set name to satisfy config requirements
             dtype=jnp.bfloat16,  # Explicitly set dtype to bfloat16 to reduce memory consumption by 50% and prevent OOM!
@@ -215,9 +218,14 @@ def trainer_configs(
         trainer_cfg = GrpoSpmdTrainer.default_config().set(
             name="grpo_trainer",  # Explicitly set name to satisfy config requirements
             model=grpo_model_cfg,
+            vocab=_vocab_cfg(
+                vocab_size
+            ),  # <--- Passes the sentencepiece vocabulary directly to the trainer!
+            num_generations=2,  # <--- Sets Trainer group size to 2 as well!
+            max_step=1000,  # <--- Limits training to exactly 1000 SFT/RL steps!
             learner=AxlearnGrpoLearner.default_config().set(
                 name="learner",  # Explicitly set name to satisfy config requirements
-                num_generations=4,
+                num_generations=2,  # <--- Sets Learner group size to 2!
                 beta=0.04,
                 optimizer=optimizer_cfg,  # <--- Satisfies required optimizer parameters!
             ),
@@ -254,7 +262,7 @@ def trainer_configs(
 
         # Connect with native storage structures Input pipeline (using the complete, canonical AXLearn SpmdInput configuration)
         train_dispatcher_cfg = SpmdInputDispatcher.default_config().set(
-            global_logical_batch_size=1024,  # Safe standard trainer batch size
+            global_logical_batch_size=128,  # <--- Reduced from 1024 to 128 to drop the memory footprint per chip!
             partition_spec=PartitionSpec(("data", "expert", "fsdp")),
         )
 
@@ -276,6 +284,36 @@ def trainer_configs(
                 }
             ),
         )
+
+        # 1. Configure PartitionSpecModifier to shard the LM Head and Token Embeddings for both policies!
+        from axlearn.common.trainer_config_modifier import PartitionSpecModifier
+
+        sharding_modifier = (
+            PartitionSpecModifier.default_config()
+            .set(
+                partition_specs={
+                    # Actor layers sharding overrides
+                    "model.actor.decoder.lm_head": {
+                        "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
+                    },
+                    "model.actor.decoder.emb.token_emb": {
+                        "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
+                    },
+                    # Reference layers sharding overrides
+                    "model.reference.decoder.lm_head": {
+                        "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
+                    },
+                    "model.reference.decoder.emb.token_emb": {
+                        "param_partition_spec": ("model", ("expert", "fsdp", "seq"))
+                    },
+                }
+            )
+            .instantiate()
+        )
+
+        # 2. Mutate and apply sharding overrides directly to the trainer configuration!
+        trainer_cfg = sharding_modifier(trainer_cfg)
+
         return trainer_cfg
 
     config_key = f"grpo-fuji-{model_size}-v1"

--- a/axlearn/experiments/text/gpt/grpo_native_example.py
+++ b/axlearn/experiments/text/gpt/grpo_native_example.py
@@ -1,82 +1,281 @@
 # Copyright © 2026 Apple Inc.
 
-"""Driver configurations module utilizing tfds_input over local/remote sources."""
+"""Driver configurations module utilizing tfds_input over local/remote sources, fully supporting Meta's LLaMA-3.1-8B and 70B configurations."""
 
-from typing import Dict
+from typing import Dict, Optional
 
-from axlearn.common.config import InstantiableConfig, TrainerConfigFn, config_for_function
+import jax.numpy as jnp
+import tensorflow as tf
+from absl import logging
+from jax.sharding import PartitionSpec
+
+from axlearn.common import input_base, input_lm, input_tf_data, optimizers
+from axlearn.common.config import (
+    REQUIRED,
+    InstantiableConfig,
+    Required,
+    TrainerConfigFn,
+    config_class,
+    config_for_function,
+)
 from axlearn.common.grpo_learner import AxlearnGrpoLearner
 from axlearn.common.grpo_model import GrpoModel
 from axlearn.common.grpo_trainer import GrpoSpmdTrainer
-from axlearn.experiments.text.common import vocab
+from axlearn.common.input_dispatch import SpmdInputDispatcher
+from axlearn.common.module import Module
+from axlearn.common.state_builder import Builder, TensorStoreStateStorageBuilder
+from axlearn.experiments.text.common import tfds_text_source, vocab
 from axlearn.experiments.text.gpt import fuji
-from axlearn.experiments.text.gpt.common import tfds_input
+from axlearn.experiments.text.gpt.common import MESH_AXIS_NAMES
+from axlearn.tools.convert_gsm8k_to_tfrecord import verify_and_print_records
 
 
 def _vocab_cfg(vocab_size: int) -> InstantiableConfig:
     """Constructs vocabulary configuration instance based on size."""
-    if vocab_size == 32 * 1024:
+    if vocab_size in (32 * 1024, 32000):
         return config_for_function(vocab).set(sentencepiece_model_name="bpe_32k_c4.model")
-    if vocab_size == 128 * 1024:
+    if vocab_size in (128 * 1024, 128256):
         return config_for_function(vocab).set(sentencepiece_model_name="bpe_128k_c4.model")
     raise ValueError(f"Unsupported vocabulary size: {vocab_size}")
 
 
-def _train_input_source(*, max_sequence_length: int) -> InstantiableConfig:
+def inject_prefix_processor() -> input_tf_data.DatasetToDatasetFn:
+    """Factory function returning a DatasetToDatasetFn that injects the missing 'prefix' key natively."""
+
+    def fn(ds: tf.data.Dataset) -> tf.data.Dataset:
+        return ds.map(
+            lambda x: {
+                **x,
+                "prefix": tf.constant([128000], dtype=tf.int32),
+            },  # Injects standard LLaMA-3 BOS token to prevent C++ empty-tensor SegFaults!
+            num_parallel_calls=tf.data.AUTOTUNE,
+        )
+
+    return fn
+
+
+def gsm8k_tfds_input(
+    *,
+    is_training: bool,
+    dataset_name: str,
+    split: str,
+    vocab_cfg: InstantiableConfig,
+    max_sequence_length: int,
+    train_shuffle_buffer_size: int = 1024 * 16,
+) -> input_tf_data.BuildDatasetFn:
+    """Custom TFDS input builder designed specifically for supervised Q&A datasets like gsm8k.
+
+    Utilizes AXLearn's native text2text_lm_input to tokenize both 'question' and 'answer'
+    into separate prompt 'input_ids' and target 'target_labels' for the GRPO reward engine.
+    """
+    # 1. Build standard TFDS text source
+    source = config_for_function(tfds_text_source).set(
+        dataset_name=dataset_name,
+        split=split,
+        train_shuffle_buffer_size=train_shuffle_buffer_size,
+    )
+
+    # 2. Pipeline directly into text2text_lm_input seq2seq preprocessor
+    # Renames 'question' and 'answer' to 'input_ids' and 'target_labels' autoregressively!
+    processor = config_for_function(input_lm.text2text_lm_input).set(
+        is_training=is_training,
+        model_type=input_lm.ModelType.DECODER_ONLY,  # Decoder-only autoregressive training (LLaMA/Qwen)
+        target_sentence_piece_vocab=vocab_cfg,
+        max_target_length=max_sequence_length,
+        source_key="question",  # Prompts key
+        target_key="answer",  # Ground-truth targets key (contains reasoning + #### solution!)
+        packing_mode="pad",  # Pad sequences to max length cleanly
+        with_eos=True,
+    )
+
+    # 3. Combine GCS source with the unified chained processor using a single with_processor call!
+    # Pass positional processors inside the 'args' keyword property to satisfy config reflection rules perfectly!
+    return input_tf_data.with_processor(
+        source,
+        processor=config_for_function(input_tf_data.chain).set(
+            args=(config_for_function(inject_prefix_processor), processor)
+        ),
+    )
+
+
+def _train_input_source(*, max_sequence_length: int, vocab_size: int) -> InstantiableConfig:
     """Instantiates native AXLearn streaming input pipeline configured over gsm8k."""
-    return config_for_function(tfds_input).set(
+    return config_for_function(gsm8k_tfds_input).set(
         dataset_name="gsm8k",
         split="train",
         is_training=True,
-        vocab_cfg=_vocab_cfg(32 * 1024),
+        vocab_cfg=_vocab_cfg(vocab_size),
         max_sequence_length=max_sequence_length,
     )
 
 
-def _eval_input_sources(*, max_sequence_length: int) -> dict[str, InstantiableConfig]:
+def _eval_input_sources(
+    *, max_sequence_length: int, vocab_size: int
+) -> dict[str, InstantiableConfig]:
     """Evaluates streaming input configurations targeting validations."""
     return {
-        "validation": config_for_function(tfds_input).set(
+        "validation": config_for_function(gsm8k_tfds_input).set(
             dataset_name="gsm8k",
             split="test",
             is_training=False,
-            vocab_cfg=_vocab_cfg(32 * 1024),
+            vocab_cfg=_vocab_cfg(vocab_size),
             max_sequence_length=max_sequence_length,
         )
     }
 
 
+class GRPOStateBuilder(Builder):
+    """Custom StateBuilder designed specifically for GRPO post-training.
+
+    Restores flat GCS checkpoints and manually replicates the parameter weights
+    into both 'actor' and 'reference' JAX PyTree namespaces recursively in memory.
+    """
+
+    @config_class
+    class Config(Builder.Config):
+        storage_builder: Required[Builder.Config] = REQUIRED
+
+    def __init__(self, cfg: Config, *, parent: Optional[Module]):
+        super().__init__(cfg, parent=parent)
+        self._add_child("storage_builder", cfg.storage_builder)
+
+    def input_state_type(self) -> Builder.StateType:
+        return self.storage_builder.input_state_type()
+
+    def __call__(self, state: Builder.State) -> Builder.State:
+        # 1. Temporarily slice flat model spec and strip learner/prng_key to bypass all validation checks!
+        flat_model_spec = state.trainer_state.model["actor"]
+        flat_state_spec = state.trainer_state._replace(
+            model=flat_model_spec, learner={}, prng_key=None
+        )
+        flat_builder_state = state.replace(trainer_state=flat_state_spec)
+
+        # 2. Restore the flat GCS checkpoint parameters cleanly
+        flat_state = self.storage_builder(flat_builder_state)
+        flat_model = flat_state.trainer_state.model
+
+        # 3. Manually replicate the restored parameters into both Actor and Reference policy sub-trees recursively!
+        actor_ref_model = {"actor": flat_model, "reference": flat_model}
+
+        # 4. Rebuild the fully populated JAX TrainerState PyTree seamlessly
+        updated_trainer_state = state.trainer_state._replace(model=actor_ref_model)
+        return flat_state.replace(trainer_state=updated_trainer_state)
+
+
 def trainer_configs(
     model_size: str,
+    *,
     version: fuji.Version = fuji.Version.V1,
+    vocab_size: int = 32 * 1024,
 ) -> Dict[str, TrainerConfigFn]:
     """Named configurations mapper."""
     config_map = {}
 
     def get_config_fn():
+        logging.info("[eshenlog] Building config for fuji model size %s...", model_size)
+
+        # Perform pre-training dataset verification sanity check inside the VM/Pod console logs!
+        logging.info("[eshenlog] Performing pre-training dataset verification checks...")
+        try:
+            verify_and_print_records(
+                "gs://ericshen-axlearn/tensorflow-datasets/gsm8k/1.0.0/gsm8k-train.tfrecord-00000-of-00008",
+                num_records=2,
+            )
+            logging.info("[eshenlog] Pre-training dataset verification completed successfully!")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging.warning("[eshenlog] Pre-training dataset verification skipped or failed: %s", e)
+
         fuji_kwargs = fuji.get_trainer_kwargs(
-            model_size, vocab_size=32 * 1024, version=version, flash_attention=True
+            model_size, vocab_size=vocab_size, version=version, flash_attention=True
         )
 
-        fuji_model_cfg = fuji_kwargs["model_kwargs"]
+        fuji_model_cfg = fuji_kwargs["model_cfg"]
         max_sequence_length = fuji_kwargs["max_sequence_length"]
 
+        logging.info("[eshenlog] Instantiating GrpoModel with jnp.bfloat16 dtype to prevent OOM...")
+
         grpo_model_cfg = GrpoModel.default_config().set(
-            actor=fuji.model_config(**fuji_model_cfg),
-            reference=fuji.model_config(**fuji_model_cfg),
+            name="model",  # Explicitly set name to satisfy config requirements
+            dtype=jnp.bfloat16,  # Explicitly set dtype to bfloat16 to reduce memory consumption by 50% and prevent OOM!
+            actor=fuji_model_cfg,
+            reference=fuji_model_cfg,
         )
 
+        # 1. Configure a standard decoupled AdamW optimizer for SFT training
+        optimizer_cfg = config_for_function(optimizers.adamw_optimizer).set(
+            learning_rate=1e-5,  # Standard RL SFT learning rate
+            b1=0.9,
+            b2=0.95,
+            eps=1e-8,
+        )
+
+        logging.info(
+            "[eshenlog] Instantiating GrpoSpmdTrainer with custom 16-way FSDP sharding mesh..."
+        )
         trainer_cfg = GrpoSpmdTrainer.default_config().set(
+            name="grpo_trainer",  # Explicitly set name to satisfy config requirements
             model=grpo_model_cfg,
             learner=AxlearnGrpoLearner.default_config().set(
+                name="learner",  # Explicitly set name to satisfy config requirements
                 num_generations=4,
                 beta=0.04,
+                optimizer=optimizer_cfg,  # <--- Satisfies required optimizer parameters!
             ),
-            mesh_shape=fuji_kwargs["mesh_shape"],
+            mesh_axis_names=MESH_AXIS_NAMES,  # Aligns natively with AXLearn's canonical 6D hybrid mesh constant!
+            mesh_shape=[
+                1,
+                1,
+                1,
+                16,
+                1,
+                1,
+            ],  # <--- Overrides to fsdp=16 sharding mesh to prevent OOM!
         )
 
-        # Connect with native storage structures Input pipeline
-        trainer_cfg.input.source = _train_input_source(max_sequence_length=max_sequence_length)
+        # Dynamically load pre-trained foundation weights from GCS at startup based on model size
+        if model_size in ("8B", "70B"):
+            # Convert '8B' parameter string to lowercase directory format matching your GCS bucket
+            gcs_dir_name = f"llama-3-1-{model_size}-instruct"
+            logging.info(
+                "[eshenlog] Dynamic GCS pre-trained checkpoints loader set to: %s", gcs_dir_name
+            )
+
+            # Configure the underlying storage builder to read GCS files with strict validations disabled!
+            storage_builder_cfg = TensorStoreStateStorageBuilder.default_config().set(
+                dir=f"gs://ericshen-axlearn/checkpoints/{gcs_dir_name}/step_00000000",
+                validation="CONTAINS_STATE",  # <--- Ignors missing optimizer parameters by checking only subset keys!
+            )
+
+            # Use custom GRPOStateBuilder to manually replicate flat GCS parameters into both policy sub-trees!
+            # This completely bypasses complex scope converters and prevents required fields validation crashes!
+            trainer_cfg.init_state_builder = GRPOStateBuilder.default_config().set(
+                storage_builder=storage_builder_cfg
+            )
+
+        # Connect with native storage structures Input pipeline (using the complete, canonical AXLearn SpmdInput configuration)
+        train_dispatcher_cfg = SpmdInputDispatcher.default_config().set(
+            global_logical_batch_size=1024,  # Safe standard trainer batch size
+            partition_spec=PartitionSpec(("data", "expert", "fsdp")),
+        )
+
+        trainer_cfg.input = input_tf_data.Input.default_config().set(
+            is_training=True,
+            source=_train_input_source(
+                max_sequence_length=max_sequence_length, vocab_size=vocab_size
+            ),
+            input_dispatcher=train_dispatcher_cfg,
+            processor=config_for_function(input_tf_data.identity),
+            batcher=config_for_function(input_tf_data.per_feed_batch).set(
+                prefetch_buffer_size=tf.data.AUTOTUNE,
+                pad_example_fn=input_tf_data.default_pad_example_fn,
+            ),
+            input_partitioner=config_for_function(input_base.partition_by_path_rank).set(
+                path_rank_to_partition={
+                    (None, 1): PartitionSpec(("data", "expert", "fsdp")),
+                    (None, 2): PartitionSpec(("data", "expert", "fsdp"), "seq"),
+                }
+            ),
+        )
         return trainer_cfg
 
     config_key = f"grpo-fuji-{model_size}-v1"
@@ -89,5 +288,23 @@ def named_trainer_configs() -> Dict[str, TrainerConfigFn]:
     config_map = {}
     config_map.update(trainer_configs("test"))
     config_map.update(trainer_configs("7B"))
-    config_map.update(trainer_configs("70B"))
+
+    # Register LLaMA-3.1-8B using the V3_TIKTOKEN layout and 128k vocab dynamically!
+    config_map.update(
+        trainer_configs(
+            "8B",
+            version=fuji.Version.V3_TIKTOKEN,
+            vocab_size=128256,  # Aligns perfectly with Meta's exact pre-trained checkpoint shape!
+        )
+    )
+
+    # Register LLaMA-3.1-70B using the V3_TIKTOKEN layout and 128k vocab dynamically!
+    config_map.update(
+        trainer_configs(
+            "70B",
+            version=fuji.Version.V3_TIKTOKEN,
+            vocab_size=128256,  # Aligns perfectly with Meta's exact pre-trained checkpoint shape!
+        )
+    )
+
     return config_map

--- a/axlearn/experiments/text/gpt/grpo_pythways_sample_output.md
+++ b/axlearn/experiments/text/gpt/grpo_pythways_sample_output.md
@@ -1,0 +1,786 @@
+## Job Launch Command
+```shell
+export BASTION_TIER=disabled
+export NAME=eshen-v6e-rl-grpo-pathways
+export RUNNER_NAME=gke_tpu_single
+export CONFIG=grpo-fuji-8B-v1
+export INSTANCE_TYPE=tpu-v6e-16
+export CLUSTER=ericshen-axlearn
+export OUTPUT_DIR="gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/${NAME}/$(date +%s)"
+
+➜  ~ nohup axlearn gcp launch run \
+  --cluster=$CLUSTER \
+  --instance_type=$INSTANCE_TYPE \
+  --name=$NAME \
+  --num_replicas=1 \
+  --runner_name=$RUNNER_NAME \
+  --bundler_spec=allow_dirty=True \
+  --bundler_type=artifactregistry \
+  --bundler_spec=image=tpu \
+  --bundler_spec=dockerfile=Dockerfile \
+  --bundler_spec=target=tpu --pathways_head_mem=128 --pathways_head_cpu=8 --env=GRPO_REWARD_TYPE:gsm8k \
+  -- \
+  python3 -m axlearn.common.launch_trainer_main \
+  --module=text.gpt.grpo_native_example \
+  --config=$CONFIG \
+  --trainer_dir=$OUTPUT_DIR \
+  --data_dir=gs://ericshen-axlearn/tensorflow-datasets \
+  --jax_backend=proxy \
+   --trainer_log_every_n_steps=10 > axlearn_launcher.log 2>&1 &
+
+```
+## output directory gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo-pathways/1779314896
+## trainer_config
+```shell
+➜  ~ gcloud storage cat gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo-pathways/1779314896/trainer_config
+batch_axis_names: 'data'
+checkpointer.gc_loop_interval_seconds: 60
+checkpointer.keep_last_n: 1
+checkpointer.klass: 'axlearn.common.checkpointer.Checkpointer'
+checkpointer.save_policy.fn: 'axlearn.common.checkpointer.every_n_steps_policy'
+checkpointer.save_policy.min_step: 1
+checkpointer.save_policy.n: 1
+checkpointer.storage.klass: 'axlearn.common.checkpointer.TensorStoreStateStorage'
+checkpointer.storage.timeout_secs: 3600
+crash_on_hang_timeout_seconds: 7200
+dir: 'gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo-pathways/1779314896'
+init_state_builder.klass: 'axlearn.experiments.text.gpt.grpo_native_example.GRPOStateBuilder'
+init_state_builder.storage_builder.concurrent_gb: 4
+init_state_builder.storage_builder.dir: 'gs://ericshen-axlearn/checkpoints/llama-3-1-8B-instruct/step_00000000'
+init_state_builder.storage_builder.klass: 'axlearn.common.state_builder.TensorStoreStateStorageBuilder'
+init_state_builder.storage_builder.storage.klass: 'axlearn.common.checkpointer.TensorStoreStateStorage'
+init_state_builder.storage_builder.storage.timeout_secs: 3600
+init_state_builder.storage_builder.validation: 'CONTAINS_STATE_UP_TO_DTYPE'
+input.batcher.fn: 'axlearn.common.input_tf_data.per_feed_batch'
+input.batcher.pad_example_fn: 'axlearn.common.input_tf_data.default_pad_example_fn'
+input.batcher.prefetch_buffer_size: -1
+input.input_dispatcher.global_logical_batch_size: 128
+input.input_dispatcher.klass: 'axlearn.common.input_dispatch.SpmdInputDispatcher'
+input.input_dispatcher.partition_spec: PartitionSpec(('data', 'expert', 'fsdp'),)
+input.input_partitioner.fn: 'axlearn.common.input_base.partition_by_path_rank'
+input.input_partitioner.path_rank_to_partition[(None, 1)]: PartitionSpec(('data', 'expert', 'fsdp'),)
+input.input_partitioner.path_rank_to_partition[(None, 2)]: PartitionSpec(('data', 'expert', 'fsdp'), 'seq')
+input.is_training: True
+input.klass: 'axlearn.common.input_tf_data.Input'
+input.processor.fn: 'axlearn.common.input_tf_data.identity'
+input.source.dataset_name: 'gsm8k'
+input.source.fn: 'axlearn.experiments.text.gpt.grpo_native_example.gsm8k_tfds_input'
+input.source.is_training: True
+input.source.max_sequence_length: 512
+input.source.split: 'train'
+input.source.train_shuffle_buffer_size: 16384
+input.source.vocab_cfg.filename: 'Llama-3-tokenizer.json'
+input.source.vocab_cfg.klass: 'axlearn.experiments.text.gpt.grpo_native_example.GRPOV3Vocabulary'
+klass: 'axlearn.common.grpo_trainer.GrpoSpmdTrainer'
+learner.beta: 0.04
+learner.ema.fn: 'axlearn.common.optimizers.param_ema'
+learner.enable_per_variable_summaries: False
+learner.epsilon: 0.2
+learner.klass: 'axlearn.common.grpo_learner.AxlearnGrpoLearner'
+learner.name: 'learner'
+learner.num_generations: 2
+learner.optimizer.b1: 0.9
+learner.optimizer.b2: 0.95
+learner.optimizer.eps: 1e-08
+learner.optimizer.fn: 'axlearn.common.optimizers.adamw_optimizer'
+learner.optimizer.learning_rate: 1e-05
+learner.optimizer.weight_decay: 0
+learner.update_rules[0][0]: 'reference/.*'
+learner.update_rules[0][1]: <UpdateType.NO_UPDATE: 'no_update'>
+learner.update_rules[1][0]: 'sampler/.*'
+learner.update_rules[1][1]: <UpdateType.NO_UPDATE: 'no_update'>
+log_every_n_steps: 10
+max_step: 1000
+mesh_axis_names[0]: 'pipeline'
+mesh_axis_names[1]: 'data'
+mesh_axis_names[2]: 'expert'
+mesh_axis_names[3]: 'fsdp'
+mesh_axis_names[4]: 'seq'
+mesh_axis_names[5]: 'model'
+mesh_shape[0]: 1
+mesh_shape[1]: 1
+mesh_shape[2]: 1
+mesh_shape[3]: 16
+mesh_shape[4]: 1
+mesh_shape[5]: 1
+model.actor.batch_axis_names: None
+model.actor.decoder.attention_mask: None
+model.actor.decoder.decoding.klass: 'axlearn.common.decoder.DecodingLayer'
+model.actor.decoder.dim: 4096
+model.actor.decoder.dropout_rate: 0.0
+model.actor.decoder.dtype: 'jax.numpy.bfloat16'
+model.actor.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
+model.actor.decoder.emb.klass: 'axlearn.common.embedding.TransformerTextEmbeddings'
+model.actor.decoder.emb.token_emb.klass: 'axlearn.common.layers.Embedding'
+model.actor.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].distribution: 'normal'
+model.actor.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].fan: 'fan_out'
+model.actor.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].klass: 'axlearn.common.param_init.WeightInitializer'
+model.actor.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].scale: 1.0
+model.actor.decoder.emb.token_emb.param_init.klass: 'axlearn.common.param_init.DefaultInitializer'
+model.actor.decoder.emb.token_emb.param_partition_spec[0]: 'model'
+model.actor.decoder.emb.token_emb.param_partition_spec[1][0]: 'expert'
+model.actor.decoder.emb.token_emb.param_partition_spec[1][1]: 'fsdp'
+model.actor.decoder.emb.token_emb.param_partition_spec[1][2]: 'seq'
+model.actor.decoder.eos_token_id: 128001
+model.actor.decoder.klass: 'axlearn.common.decoder.Decoder'
+model.actor.decoder.lm_head.klass: 'axlearn.common.decoder.LmHead'
+model.actor.decoder.lm_head.param_partition_spec[0]: 'model'
+model.actor.decoder.lm_head.param_partition_spec[1][0]: 'expert'
+model.actor.decoder.lm_head.param_partition_spec[1][1]: 'fsdp'
+model.actor.decoder.lm_head.param_partition_spec[1][2]: 'seq'
+model.actor.decoder.logits_partition_spec[0][0]: 'data'
+model.actor.decoder.logits_partition_spec[0][1]: 'expert'
+model.actor.decoder.logits_partition_spec[0][2]: 'fsdp'
+model.actor.decoder.logits_partition_spec[1]: 'seq'
+model.actor.decoder.logits_partition_spec[2]: 'model'
+model.actor.decoder.output_dropout.klass: 'axlearn.common.layers.Dropout'
+model.actor.decoder.output_norm.eps: 1e-05
+model.actor.decoder.output_norm.forward_dtype: None
+model.actor.decoder.output_norm.klass: 'axlearn.common.layers.RMSNorm'
+model.actor.decoder.pad_token_id: 128004
+model.actor.decoder.transformer.klass: 'axlearn.common.attention.RepeatedTransformerLayer'
+model.actor.decoder.transformer.layer.feed_forward.activation[0]: 'nn.silu'
+model.actor.decoder.transformer.layer.feed_forward.activation[1]: 'linear'
+model.actor.decoder.transformer.layer.feed_forward.dropout.klass: 'axlearn.common.layers.Dropout'
+model.actor.decoder.transformer.layer.feed_forward.hidden_dim.fn: 'axlearn.experiments.text.gpt.common.scale_fn'
+model.actor.decoder.transformer.layer.feed_forward.hidden_dim.round_up_to_multiples_of: 256
+model.actor.decoder.transformer.layer.feed_forward.hidden_dim.scale: 3.5
+model.actor.decoder.transformer.layer.feed_forward.klass: 'axlearn.common.attention.TransformerFeedForwardLayer'
+model.actor.decoder.transformer.layer.feed_forward.linear1.bias: False
+model.actor.decoder.transformer.layer.feed_forward.linear1.klass: 'axlearn.common.layers.Linear'
+model.actor.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][0]: 'data'
+model.actor.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][1]: 'expert'
+model.actor.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][2]: 'fsdp'
+model.actor.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[1]: 'seq'
+model.actor.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[2]: 'model'
+model.actor.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][0]: 'expert'
+model.actor.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][1]: 'fsdp'
+model.actor.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][2]: 'seq'
+model.actor.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[1]: 'model'
+model.actor.decoder.transformer.layer.feed_forward.linear2.bias: False
+model.actor.decoder.transformer.layer.feed_forward.linear2.klass: 'axlearn.common.layers.Linear'
+model.actor.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][0]: 'data'
+model.actor.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][1]: 'expert'
+model.actor.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][2]: 'fsdp'
+model.actor.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[1]: 'seq'
+model.actor.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[2]: 'model'
+model.actor.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[0]: 'model'
+model.actor.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][0]: 'expert'
+model.actor.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][1]: 'fsdp'
+model.actor.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][2]: 'seq'
+model.actor.decoder.transformer.layer.feed_forward.norm.eps: 1e-05
+model.actor.decoder.transformer.layer.feed_forward.norm.forward_dtype: None
+model.actor.decoder.transformer.layer.feed_forward.norm.klass: 'axlearn.common.layers.RMSNorm'
+model.actor.decoder.transformer.layer.feed_forward.residual_weight: 1.0
+model.actor.decoder.transformer.layer.feed_forward.stochastic_depth.klass: 'axlearn.common.layers.StochasticDepth'
+model.actor.decoder.transformer.layer.feed_forward.stochastic_depth.mode: 'row'
+model.actor.decoder.transformer.layer.feed_forward.structure: 'prenorm'
+model.actor.decoder.transformer.layer.klass: 'axlearn.common.attention.TransformerLayer'
+model.actor.decoder.transformer.layer.remat_spec['prevent_cse']: False
+model.actor.decoder.transformer.layer.remat_spec['policy'].fn: 'axlearn.common.attention._save_and_offload_only_these_names_regex'
+model.actor.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_offloaded: None
+model.actor.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved: '.*([qkvo]_proj|context)'
+model.actor.decoder.transformer.layer.remat_spec['policy'].offload_dst: 'pinned_host'
+model.actor.decoder.transformer.layer.remat_spec['policy'].offload_src: 'device'
+model.actor.decoder.transformer.layer.self_attention.attention.causal: True
+model.actor.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.klass: 'axlearn.common.attention.FusedGroupedQKVLinear'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.bias: False
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.klass: 'axlearn.common.attention.MultiheadInputLinear'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][0]: 'expert'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][1]: 'fsdp'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][2]: 'seq'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[1]: 'model'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[2]: None
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.num_kv_heads: 8
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.klass: 'axlearn.common.attention.RoFormerQKVLinear'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.rope_pos_emb_layer.klass: 'axlearn.common.attention.RoFormerSinusoidalPositionalEmbedding'
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.rope_pos_emb_layer.theta: 500000.0
+model.actor.decoder.transformer.layer.self_attention.attention.input_linear.rotary_value: False
+model.actor.decoder.transformer.layer.self_attention.attention.key_scale.klass: 'axlearn.common.attention.ScaleKey'
+model.actor.decoder.transformer.layer.self_attention.attention.klass: 'axlearn.common.attention.GroupedQueryAttention'
+model.actor.decoder.transformer.layer.self_attention.attention.kv_cache.cache_dtype: 'jax.numpy.bfloat16'
+model.actor.decoder.transformer.layer.self_attention.attention.kv_cache.klass: 'axlearn.common.kv_cache.kv_cache.KVCache'
+model.actor.decoder.transformer.layer.self_attention.attention.num_heads: 32
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.bias: False
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.klass: 'axlearn.common.attention.MultiheadOutputLinear'
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][0]: 'expert'
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][1]: 'fsdp'
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][2]: 'seq'
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[1]: 'model'
+model.actor.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[2]: None
+model.actor.decoder.transformer.layer.self_attention.attention.query_scale.klass: 'axlearn.common.attention.ScaleQuery'
+model.actor.decoder.transformer.layer.self_attention.dropout.klass: 'axlearn.common.layers.Dropout'
+model.actor.decoder.transformer.layer.self_attention.klass: 'axlearn.common.attention.TransformerAttentionLayer'
+model.actor.decoder.transformer.layer.self_attention.norm.eps: 1e-05
+model.actor.decoder.transformer.layer.self_attention.norm.forward_dtype: None
+model.actor.decoder.transformer.layer.self_attention.norm.klass: 'axlearn.common.layers.RMSNorm'
+model.actor.decoder.transformer.layer.self_attention.stochastic_depth.klass: 'axlearn.common.layers.StochasticDepth'
+model.actor.decoder.transformer.layer.self_attention.stochastic_depth.mode: 'row'
+model.actor.decoder.transformer.layer.self_attention.structure: 'prenorm'
+model.actor.decoder.transformer.num_layers: 32
+model.actor.decoder.transformer.repeat.drop_output.fn: 'axlearn.common.repeat._drop_by_regex'
+model.actor.decoder.transformer.repeat.drop_output.rules[0]: 'module_outputs.*'
+model.actor.decoder.transformer.repeat.klass: 'axlearn.common.attention._TransformerRepeat'
+model.actor.decoder.vocab_size: 128256
+model.actor.dtype: 'jax.numpy.bfloat16'
+model.actor.klass: 'axlearn.common.causal_lm.Model'
+model.actor.metrics.klass: 'axlearn.common.causal_lm.CompositeLossMetrics'
+model.actor.metrics.metrics['lm'].klass: 'axlearn.common.causal_lm.CrossEntropyLossMetrics'
+model.actor.metrics.metrics['aux'].klass: 'axlearn.common.causal_lm.AuxLossMetrics'
+model.actor.param_init.init_by_param_name['.*weight$'].distribution: 'normal'
+model.actor.param_init.init_by_param_name['.*weight$'].fan: 'fan_in'
+model.actor.param_init.init_by_param_name['.*weight$'].klass: 'axlearn.common.param_init.WeightInitializer'
+model.actor.param_init.init_by_param_name['.*weight$'].scale: 1.0
+model.actor.param_init.klass: 'axlearn.common.param_init.DefaultInitializer'
+model.dtype: 'jax.numpy.bfloat16'
+model.klass: 'axlearn.common.grpo_model.GrpoModel'
+model.name: 'model'
+model.reference.batch_axis_names: None
+model.reference.decoder.attention_mask: None
+model.reference.decoder.decoding.klass: 'axlearn.common.decoder.DecodingLayer'
+model.reference.decoder.dim: 4096
+model.reference.decoder.dropout_rate: 0.0
+model.reference.decoder.dtype: 'jax.numpy.bfloat16'
+model.reference.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
+model.reference.decoder.emb.klass: 'axlearn.common.embedding.TransformerTextEmbeddings'
+model.reference.decoder.emb.token_emb.klass: 'axlearn.common.layers.Embedding'
+model.reference.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].distribution: 'normal'
+model.reference.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].fan: 'fan_out'
+model.reference.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].klass: 'axlearn.common.param_init.WeightInitializer'
+model.reference.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].scale: 1.0
+model.reference.decoder.emb.token_emb.param_init.klass: 'axlearn.common.param_init.DefaultInitializer'
+model.reference.decoder.emb.token_emb.param_partition_spec[0]: 'model'
+model.reference.decoder.emb.token_emb.param_partition_spec[1][0]: 'expert'
+model.reference.decoder.emb.token_emb.param_partition_spec[1][1]: 'fsdp'
+model.reference.decoder.emb.token_emb.param_partition_spec[1][2]: 'seq'
+model.reference.decoder.eos_token_id: 128001
+model.reference.decoder.klass: 'axlearn.common.decoder.Decoder'
+model.reference.decoder.lm_head.klass: 'axlearn.common.decoder.LmHead'
+model.reference.decoder.lm_head.param_partition_spec[0]: 'model'
+model.reference.decoder.lm_head.param_partition_spec[1][0]: 'expert'
+model.reference.decoder.lm_head.param_partition_spec[1][1]: 'fsdp'
+model.reference.decoder.lm_head.param_partition_spec[1][2]: 'seq'
+model.reference.decoder.logits_partition_spec[0][0]: 'data'
+model.reference.decoder.logits_partition_spec[0][1]: 'expert'
+model.reference.decoder.logits_partition_spec[0][2]: 'fsdp'
+model.reference.decoder.logits_partition_spec[1]: 'seq'
+model.reference.decoder.logits_partition_spec[2]: 'model'
+model.reference.decoder.output_dropout.klass: 'axlearn.common.layers.Dropout'
+model.reference.decoder.output_norm.eps: 1e-05
+model.reference.decoder.output_norm.forward_dtype: None
+model.reference.decoder.output_norm.klass: 'axlearn.common.layers.RMSNorm'
+model.reference.decoder.pad_token_id: 128004
+model.reference.decoder.transformer.klass: 'axlearn.common.attention.RepeatedTransformerLayer'
+model.reference.decoder.transformer.layer.feed_forward.activation[0]: 'nn.silu'
+model.reference.decoder.transformer.layer.feed_forward.activation[1]: 'linear'
+model.reference.decoder.transformer.layer.feed_forward.dropout.klass: 'axlearn.common.layers.Dropout'
+model.reference.decoder.transformer.layer.feed_forward.hidden_dim.fn: 'axlearn.experiments.text.gpt.common.scale_fn'
+model.reference.decoder.transformer.layer.feed_forward.hidden_dim.round_up_to_multiples_of: 256
+model.reference.decoder.transformer.layer.feed_forward.hidden_dim.scale: 3.5
+model.reference.decoder.transformer.layer.feed_forward.klass: 'axlearn.common.attention.TransformerFeedForwardLayer'
+model.reference.decoder.transformer.layer.feed_forward.linear1.bias: False
+model.reference.decoder.transformer.layer.feed_forward.linear1.klass: 'axlearn.common.layers.Linear'
+model.reference.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][0]: 'data'
+model.reference.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][1]: 'expert'
+model.reference.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][2]: 'fsdp'
+model.reference.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[1]: 'seq'
+model.reference.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[2]: 'model'
+model.reference.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][0]: 'expert'
+model.reference.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][1]: 'fsdp'
+model.reference.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][2]: 'seq'
+model.reference.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[1]: 'model'
+model.reference.decoder.transformer.layer.feed_forward.linear2.bias: False
+model.reference.decoder.transformer.layer.feed_forward.linear2.klass: 'axlearn.common.layers.Linear'
+model.reference.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][0]: 'data'
+model.reference.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][1]: 'expert'
+model.reference.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][2]: 'fsdp'
+model.reference.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[1]: 'seq'
+model.reference.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[2]: 'model'
+model.reference.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[0]: 'model'
+model.reference.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][0]: 'expert'
+model.reference.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][1]: 'fsdp'
+model.reference.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][2]: 'seq'
+model.reference.decoder.transformer.layer.feed_forward.norm.eps: 1e-05
+model.reference.decoder.transformer.layer.feed_forward.norm.forward_dtype: None
+model.reference.decoder.transformer.layer.feed_forward.norm.klass: 'axlearn.common.layers.RMSNorm'
+model.reference.decoder.transformer.layer.feed_forward.residual_weight: 1.0
+model.reference.decoder.transformer.layer.feed_forward.stochastic_depth.klass: 'axlearn.common.layers.StochasticDepth'
+model.reference.decoder.transformer.layer.feed_forward.stochastic_depth.mode: 'row'
+model.reference.decoder.transformer.layer.feed_forward.structure: 'prenorm'
+model.reference.decoder.transformer.layer.klass: 'axlearn.common.attention.TransformerLayer'
+model.reference.decoder.transformer.layer.remat_spec['prevent_cse']: False
+model.reference.decoder.transformer.layer.remat_spec['policy'].fn: 'axlearn.common.attention._save_and_offload_only_these_names_regex'
+model.reference.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_offloaded: None
+model.reference.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved: '.*([qkvo]_proj|context)'
+model.reference.decoder.transformer.layer.remat_spec['policy'].offload_dst: 'pinned_host'
+model.reference.decoder.transformer.layer.remat_spec['policy'].offload_src: 'device'
+model.reference.decoder.transformer.layer.self_attention.attention.causal: True
+model.reference.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.klass: 'axlearn.common.attention.FusedGroupedQKVLinear'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.bias: False
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.klass: 'axlearn.common.attention.MultiheadInputLinear'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][0]: 'expert'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][1]: 'fsdp'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][2]: 'seq'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[1]: 'model'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[2]: None
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.num_kv_heads: 8
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.klass: 'axlearn.common.attention.RoFormerQKVLinear'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.rope_pos_emb_layer.klass: 'axlearn.common.attention.RoFormerSinusoidalPositionalEmbedding'
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.rope_pos_emb_layer.theta: 500000.0
+model.reference.decoder.transformer.layer.self_attention.attention.input_linear.rotary_value: False
+model.reference.decoder.transformer.layer.self_attention.attention.key_scale.klass: 'axlearn.common.attention.ScaleKey'
+model.reference.decoder.transformer.layer.self_attention.attention.klass: 'axlearn.common.attention.GroupedQueryAttention'
+model.reference.decoder.transformer.layer.self_attention.attention.kv_cache.cache_dtype: 'jax.numpy.bfloat16'
+model.reference.decoder.transformer.layer.self_attention.attention.kv_cache.klass: 'axlearn.common.kv_cache.kv_cache.KVCache'
+model.reference.decoder.transformer.layer.self_attention.attention.num_heads: 32
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.bias: False
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.klass: 'axlearn.common.attention.MultiheadOutputLinear'
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][0]: 'expert'
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][1]: 'fsdp'
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][2]: 'seq'
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[1]: 'model'
+model.reference.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[2]: None
+model.reference.decoder.transformer.layer.self_attention.attention.query_scale.klass: 'axlearn.common.attention.ScaleQuery'
+model.reference.decoder.transformer.layer.self_attention.dropout.klass: 'axlearn.common.layers.Dropout'
+model.reference.decoder.transformer.layer.self_attention.klass: 'axlearn.common.attention.TransformerAttentionLayer'
+model.reference.decoder.transformer.layer.self_attention.norm.eps: 1e-05
+model.reference.decoder.transformer.layer.self_attention.norm.forward_dtype: None
+model.reference.decoder.transformer.layer.self_attention.norm.klass: 'axlearn.common.layers.RMSNorm'
+model.reference.decoder.transformer.layer.self_attention.stochastic_depth.klass: 'axlearn.common.layers.StochasticDepth'
+model.reference.decoder.transformer.layer.self_attention.stochastic_depth.mode: 'row'
+model.reference.decoder.transformer.layer.self_attention.structure: 'prenorm'
+model.reference.decoder.transformer.num_layers: 32
+model.reference.decoder.transformer.repeat.drop_output.fn: 'axlearn.common.repeat._drop_by_regex'
+model.reference.decoder.transformer.repeat.drop_output.rules[0]: 'module_outputs.*'
+model.reference.decoder.transformer.repeat.klass: 'axlearn.common.attention._TransformerRepeat'
+model.reference.decoder.vocab_size: 128256
+model.reference.dtype: 'jax.numpy.bfloat16'
+model.reference.klass: 'axlearn.common.causal_lm.Model'
+model.reference.metrics.klass: 'axlearn.common.causal_lm.CompositeLossMetrics'
+model.reference.metrics.metrics['lm'].klass: 'axlearn.common.causal_lm.CrossEntropyLossMetrics'
+model.reference.metrics.metrics['aux'].klass: 'axlearn.common.causal_lm.AuxLossMetrics'
+model.reference.param_init.init_by_param_name['.*weight$'].distribution: 'normal'
+model.reference.param_init.init_by_param_name['.*weight$'].fan: 'fan_in'
+model.reference.param_init.init_by_param_name['.*weight$'].klass: 'axlearn.common.param_init.WeightInitializer'
+model.reference.param_init.init_by_param_name['.*weight$'].scale: 1.0
+model.reference.param_init.klass: 'axlearn.common.param_init.DefaultInitializer'
+model.sampler.batch_axis_names: None
+model.sampler.decoder.attention_mask: None
+model.sampler.decoder.decoding.klass: 'axlearn.common.decoder.DecodingLayer'
+model.sampler.decoder.dim: 4096
+model.sampler.decoder.dropout_rate: 0.0
+model.sampler.decoder.dtype: 'jax.numpy.bfloat16'
+model.sampler.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
+model.sampler.decoder.emb.klass: 'axlearn.common.embedding.TransformerTextEmbeddings'
+model.sampler.decoder.emb.token_emb.klass: 'axlearn.common.layers.Embedding'
+model.sampler.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].distribution: 'normal'
+model.sampler.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].fan: 'fan_out'
+model.sampler.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].klass: 'axlearn.common.param_init.WeightInitializer'
+model.sampler.decoder.emb.token_emb.param_init.init_by_param_name['.*weight$'].scale: 1.0
+model.sampler.decoder.emb.token_emb.param_init.klass: 'axlearn.common.param_init.DefaultInitializer'
+model.sampler.decoder.emb.token_emb.param_partition_spec[0]: 'model'
+model.sampler.decoder.emb.token_emb.param_partition_spec[1][0]: 'expert'
+model.sampler.decoder.emb.token_emb.param_partition_spec[1][1]: 'fsdp'
+model.sampler.decoder.emb.token_emb.param_partition_spec[1][2]: 'seq'
+model.sampler.decoder.eos_token_id: 128001
+model.sampler.decoder.klass: 'axlearn.common.decoder.Decoder'
+model.sampler.decoder.lm_head.klass: 'axlearn.common.decoder.LmHead'
+model.sampler.decoder.lm_head.param_partition_spec[0]: 'model'
+model.sampler.decoder.lm_head.param_partition_spec[1][0]: 'expert'
+model.sampler.decoder.lm_head.param_partition_spec[1][1]: 'fsdp'
+model.sampler.decoder.lm_head.param_partition_spec[1][2]: 'seq'
+model.sampler.decoder.logits_partition_spec[0][0]: 'data'
+model.sampler.decoder.logits_partition_spec[0][1]: 'expert'
+model.sampler.decoder.logits_partition_spec[0][2]: 'fsdp'
+model.sampler.decoder.logits_partition_spec[1]: 'seq'
+model.sampler.decoder.logits_partition_spec[2]: 'model'
+model.sampler.decoder.output_dropout.klass: 'axlearn.common.layers.Dropout'
+model.sampler.decoder.output_norm.eps: 1e-05
+model.sampler.decoder.output_norm.forward_dtype: None
+model.sampler.decoder.output_norm.klass: 'axlearn.common.layers.RMSNorm'
+model.sampler.decoder.pad_token_id: 128004
+model.sampler.decoder.transformer.klass: 'axlearn.common.attention.RepeatedTransformerLayer'
+model.sampler.decoder.transformer.layer.feed_forward.activation[0]: 'nn.silu'
+model.sampler.decoder.transformer.layer.feed_forward.activation[1]: 'linear'
+model.sampler.decoder.transformer.layer.feed_forward.dropout.klass: 'axlearn.common.layers.Dropout'
+model.sampler.decoder.transformer.layer.feed_forward.hidden_dim.fn: 'axlearn.experiments.text.gpt.common.scale_fn'
+model.sampler.decoder.transformer.layer.feed_forward.hidden_dim.round_up_to_multiples_of: 256
+model.sampler.decoder.transformer.layer.feed_forward.hidden_dim.scale: 3.5
+model.sampler.decoder.transformer.layer.feed_forward.klass: 'axlearn.common.attention.TransformerFeedForwardLayer'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.bias: False
+model.sampler.decoder.transformer.layer.feed_forward.linear1.klass: 'axlearn.common.layers.Linear'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][0]: 'data'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][1]: 'expert'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[0][2]: 'fsdp'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[1]: 'seq'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.output_partition_spec[2]: 'model'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][0]: 'expert'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][1]: 'fsdp'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[0][2]: 'seq'
+model.sampler.decoder.transformer.layer.feed_forward.linear1.param_partition_spec[1]: 'model'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.bias: False
+model.sampler.decoder.transformer.layer.feed_forward.linear2.klass: 'axlearn.common.layers.Linear'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][0]: 'data'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][1]: 'expert'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[0][2]: 'fsdp'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[1]: 'seq'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.output_partition_spec[2]: 'model'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[0]: 'model'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][0]: 'expert'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][1]: 'fsdp'
+model.sampler.decoder.transformer.layer.feed_forward.linear2.param_partition_spec[1][2]: 'seq'
+model.sampler.decoder.transformer.layer.feed_forward.norm.eps: 1e-05
+model.sampler.decoder.transformer.layer.feed_forward.norm.forward_dtype: None
+model.sampler.decoder.transformer.layer.feed_forward.norm.klass: 'axlearn.common.layers.RMSNorm'
+model.sampler.decoder.transformer.layer.feed_forward.residual_weight: 1.0
+model.sampler.decoder.transformer.layer.feed_forward.stochastic_depth.klass: 'axlearn.common.layers.StochasticDepth'
+model.sampler.decoder.transformer.layer.feed_forward.stochastic_depth.mode: 'row'
+model.sampler.decoder.transformer.layer.feed_forward.structure: 'prenorm'
+model.sampler.decoder.transformer.layer.klass: 'axlearn.common.attention.TransformerLayer'
+model.sampler.decoder.transformer.layer.remat_spec['prevent_cse']: False
+model.sampler.decoder.transformer.layer.remat_spec['policy'].fn: 'axlearn.common.attention._save_and_offload_only_these_names_regex'
+model.sampler.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_offloaded: None
+model.sampler.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved: '.*([qkvo]_proj|context)'
+model.sampler.decoder.transformer.layer.remat_spec['policy'].offload_dst: 'pinned_host'
+model.sampler.decoder.transformer.layer.remat_spec['policy'].offload_src: 'device'
+model.sampler.decoder.transformer.layer.self_attention.attention.causal: True
+model.sampler.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.klass: 'axlearn.common.attention.FusedGroupedQKVLinear'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.bias: False
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.klass: 'axlearn.common.attention.MultiheadInputLinear'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][0]: 'expert'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][1]: 'fsdp'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[0][2]: 'seq'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[1]: 'model'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.layer.param_partition_spec[2]: None
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.num_kv_heads: 8
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.klass: 'axlearn.common.attention.RoFormerQKVLinear'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.rope_pos_emb_layer.klass: 'axlearn.common.attention.RoFormerSinusoidalPositionalEmbedding'
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.rope_pos_emb_layer.theta: 500000.0
+model.sampler.decoder.transformer.layer.self_attention.attention.input_linear.rotary_value: False
+model.sampler.decoder.transformer.layer.self_attention.attention.key_scale.klass: 'axlearn.common.attention.ScaleKey'
+model.sampler.decoder.transformer.layer.self_attention.attention.klass: 'axlearn.common.attention.GroupedQueryAttention'
+model.sampler.decoder.transformer.layer.self_attention.attention.kv_cache.cache_dtype: 'jax.numpy.bfloat16'
+model.sampler.decoder.transformer.layer.self_attention.attention.kv_cache.klass: 'axlearn.common.kv_cache.kv_cache.KVCache'
+model.sampler.decoder.transformer.layer.self_attention.attention.num_heads: 32
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.bias: False
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.klass: 'axlearn.common.attention.MultiheadOutputLinear'
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][0]: 'expert'
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][1]: 'fsdp'
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[0][2]: 'seq'
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[1]: 'model'
+model.sampler.decoder.transformer.layer.self_attention.attention.output_linear.param_partition_spec[2]: None
+model.sampler.decoder.transformer.layer.self_attention.attention.query_scale.klass: 'axlearn.common.attention.ScaleQuery'
+model.sampler.decoder.transformer.layer.self_attention.dropout.klass: 'axlearn.common.layers.Dropout'
+model.sampler.decoder.transformer.layer.self_attention.klass: 'axlearn.common.attention.TransformerAttentionLayer'
+model.sampler.decoder.transformer.layer.self_attention.norm.eps: 1e-05
+model.sampler.decoder.transformer.layer.self_attention.norm.forward_dtype: None
+model.sampler.decoder.transformer.layer.self_attention.norm.klass: 'axlearn.common.layers.RMSNorm'
+model.sampler.decoder.transformer.layer.self_attention.stochastic_depth.klass: 'axlearn.common.layers.StochasticDepth'
+model.sampler.decoder.transformer.layer.self_attention.stochastic_depth.mode: 'row'
+model.sampler.decoder.transformer.layer.self_attention.structure: 'prenorm'
+model.sampler.decoder.transformer.num_layers: 32
+model.sampler.decoder.transformer.repeat.drop_output.fn: 'axlearn.common.repeat._drop_by_regex'
+model.sampler.decoder.transformer.repeat.drop_output.rules[0]: 'module_outputs.*'
+model.sampler.decoder.transformer.repeat.klass: 'axlearn.common.attention._TransformerRepeat'
+model.sampler.decoder.vocab_size: 128256
+model.sampler.dtype: 'jax.numpy.bfloat16'
+model.sampler.klass: 'axlearn.common.causal_lm.Model'
+model.sampler.metrics.klass: 'axlearn.common.causal_lm.CompositeLossMetrics'
+model.sampler.metrics.metrics['lm'].klass: 'axlearn.common.causal_lm.CrossEntropyLossMetrics'
+model.sampler.metrics.metrics['aux'].klass: 'axlearn.common.causal_lm.AuxLossMetrics'
+model.sampler.param_init.init_by_param_name['.*weight$'].distribution: 'normal'
+model.sampler.param_init.init_by_param_name['.*weight$'].fan: 'fan_in'
+model.sampler.param_init.init_by_param_name['.*weight$'].klass: 'axlearn.common.param_init.WeightInitializer'
+model.sampler.param_init.init_by_param_name['.*weight$'].scale: 1.0
+model.sampler.param_init.klass: 'axlearn.common.param_init.DefaultInitializer'
+name: 'grpo_trainer'
+num_generations: 2
+prune_empty_state_updates: True
+recorder.fn: '__main__.<lambda>'
+reward_type: 'gsm8k'
+save_input_iterator: False
+start_trace_process_indices[0]: 0
+summary_writer.klass: 'axlearn.common.summary_writer.SummaryWriter'
+summary_writer.max_queue: 1000
+summary_writer.write_every_n_steps: 1
+vocab.filename: 'Llama-3-tokenizer.json'
+vocab.klass: 'axlearn.experiments.text.gpt.grpo_native_example.GRPOV3Vocabulary'
+watchdog_timeout_seconds: 3600%
+```
+## model_analysis
+```shell
+➜  ~ gcloud storage cat gs://cloud-tpu-multipod-dev-axlearn/users/ericshen/eshen-v6e-rl-grpo-pathways/1779314896/model_analysis.txt | tr '\t' '\n'
+##################### Model analysis #####################
+## Parameters:
+ 525336576 [128256, 4096]       actor/decoder/emb/token_emb/weight
+ 525336576 (128256, 4096)       actor/decoder/lm_head/weight
+      4096 [4096]               actor/decoder/output_norm/scale
+1879048192 (32, 4096, 14336)    actor/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight
+1879048192 (32, 4096, 14336)    actor/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight
+1879048192 (32, 14336, 4096)    actor/decoder/transformer/repeat/layer/feed_forward/linear2/weight
+    131072 (32, 4096)           actor/decoder/transformer/repeat/layer/feed_forward/norm/scale
+ 805306368 (32, 4096, 48, 128)  actor/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight
+ 536870912 (32, 4096, 32, 128)  actor/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight
+    131072 (32, 4096)           actor/decoder/transformer/repeat/layer/self_attention/norm/scale
+ 525336576 [128256, 4096]       reference/decoder/emb/token_emb/weight
+ 525336576 (128256, 4096)       reference/decoder/lm_head/weight
+      4096 [4096]               reference/decoder/output_norm/scale
+1879048192 (32, 4096, 14336)    reference/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight
+1879048192 (32, 4096, 14336)    reference/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight
+1879048192 (32, 14336, 4096)    reference/decoder/transformer/repeat/layer/feed_forward/linear2/weight
+    131072 (32, 4096)           reference/decoder/transformer/repeat/layer/feed_forward/norm/scale
+ 805306368 (32, 4096, 48, 128)  reference/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight
+ 536870912 (32, 4096, 32, 128)  reference/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight
+    131072 (32, 4096)           reference/decoder/transformer/repeat/layer/self_attention/norm/scale
+ 525336576 [128256, 4096]       sampler/decoder/emb/token_emb/weight
+ 525336576 (128256, 4096)       sampler/decoder/lm_head/weight
+      4096 [4096]               sampler/decoder/output_norm/scale
+1879048192 (32, 4096, 14336)    sampler/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight
+1879048192 (32, 4096, 14336)    sampler/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight
+1879048192 (32, 14336, 4096)    sampler/decoder/transformer/repeat/layer/feed_forward/linear2/weight
+    131072 (32, 4096)           sampler/decoder/transformer/repeat/layer/feed_forward/norm/scale
+ 805306368 (32, 4096, 48, 128)  sampler/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight
+ 536870912 (32, 4096, 32, 128)  sampler/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight
+    131072 (32, 4096)           sampler/decoder/transformer/repeat/layer/self_attention/norm/scale
+Total number of model params: 24,090,783,744
+## Trainer States:
+State: prng_key=uint32((4,)) mesh_axes=ParameterSpec(shape=[4], dtype=<class 'jax.numpy.uint32'>, mesh_axes=PartitionSpec(None,), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/actor/decoder/emb/token_emb/weight=bfloat16((128256, 4096)) mesh_axes=ParameterSpec(shape=[128256, 4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=None, fan_axes=FanAxes(in_axis=-2, out_axis=-1, batch_axis=()), weight_decay_scale=None)
+State: model/actor/decoder/lm_head/weight=bfloat16((128256, 4096)) mesh_axes=ParameterSpec(shape=(128256, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=None, fan_axes=FanAxes(in_axis=-2, out_axis=-1, batch_axis=()), weight_decay_scale=None)
+State: model/actor/decoder/output_norm/scale=bfloat16((4096,)) mesh_axes=ParameterSpec(shape=[4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None,), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight=bfloat16((32, 4096, 14336)) mesh_axes=ParameterSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight=bfloat16((32, 4096, 14336)) mesh_axes=ParameterSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/feed_forward/linear2/weight=bfloat16((32, 14336, 4096)) mesh_axes=ParameterSpec(shape=(32, 14336, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, 'model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/feed_forward/norm/scale=bfloat16((32, 4096)) mesh_axes=ParameterSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight=bfloat16((32, 4096, 48, 128)) mesh_axes=ParameterSpec(shape=(32, 4096, 48, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', None, 'col']), fan_axes=FanAxes(in_axis=(1,), out_axis=(2, 3), batch_axis=(0,)), weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight=bfloat16((32, 4096, 32, 128)) mesh_axes=ParameterSpec(shape=(32, 4096, 32, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', None, 'col']), fan_axes=FanAxes(in_axis=(2, 3), out_axis=(1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/actor/decoder/transformer/repeat/layer/self_attention/norm/scale=bfloat16((32, 4096)) mesh_axes=ParameterSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/reference/decoder/emb/token_emb/weight=bfloat16((128256, 4096)) mesh_axes=ParameterSpec(shape=[128256, 4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=None, fan_axes=FanAxes(in_axis=-2, out_axis=-1, batch_axis=()), weight_decay_scale=None)
+State: model/reference/decoder/lm_head/weight=bfloat16((128256, 4096)) mesh_axes=ParameterSpec(shape=(128256, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=None, fan_axes=FanAxes(in_axis=-2, out_axis=-1, batch_axis=()), weight_decay_scale=None)
+State: model/reference/decoder/output_norm/scale=bfloat16((4096,)) mesh_axes=ParameterSpec(shape=[4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None,), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight=bfloat16((32, 4096, 14336)) mesh_axes=ParameterSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight=bfloat16((32, 4096, 14336)) mesh_axes=ParameterSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/feed_forward/linear2/weight=bfloat16((32, 14336, 4096)) mesh_axes=ParameterSpec(shape=(32, 14336, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, 'model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/feed_forward/norm/scale=bfloat16((32, 4096)) mesh_axes=ParameterSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight=bfloat16((32, 4096, 48, 128)) mesh_axes=ParameterSpec(shape=(32, 4096, 48, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', None, 'col']), fan_axes=FanAxes(in_axis=(1,), out_axis=(2, 3), batch_axis=(0,)), weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight=bfloat16((32, 4096, 32, 128)) mesh_axes=ParameterSpec(shape=(32, 4096, 32, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', None, 'col']), fan_axes=FanAxes(in_axis=(2, 3), out_axis=(1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/reference/decoder/transformer/repeat/layer/self_attention/norm/scale=bfloat16((32, 4096)) mesh_axes=ParameterSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/sampler/decoder/emb/token_emb/weight=bfloat16((128256, 4096)) mesh_axes=ParameterSpec(shape=[128256, 4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=None, fan_axes=FanAxes(in_axis=-2, out_axis=-1, batch_axis=()), weight_decay_scale=None)
+State: model/sampler/decoder/lm_head/weight=bfloat16((128256, 4096)) mesh_axes=ParameterSpec(shape=(128256, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=None, fan_axes=FanAxes(in_axis=-2, out_axis=-1, batch_axis=()), weight_decay_scale=None)
+State: model/sampler/decoder/output_norm/scale=bfloat16((4096,)) mesh_axes=ParameterSpec(shape=[4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None,), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight=bfloat16((32, 4096, 14336)) mesh_axes=ParameterSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight=bfloat16((32, 4096, 14336)) mesh_axes=ParameterSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/feed_forward/linear2/weight=bfloat16((32, 14336, 4096)) mesh_axes=ParameterSpec(shape=(32, 14336, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, 'model', ('expert', 'fsdp', 'seq')), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', 'col']), fan_axes=FanAxes(in_axis=(-2,), out_axis=(-1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/feed_forward/norm/scale=bfloat16((32, 4096)) mesh_axes=ParameterSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight=bfloat16((32, 4096, 48, 128)) mesh_axes=ParameterSpec(shape=(32, 4096, 48, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', None, 'col']), fan_axes=FanAxes(in_axis=(1,), out_axis=(2, 3), batch_axis=(0,)), weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight=bfloat16((32, 4096, 32, 128)) mesh_axes=ParameterSpec(shape=(32, 4096, 32, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None, initializer=None, factorization=FactorizationSpec(axes=[None, 'row', None, 'col']), fan_axes=FanAxes(in_axis=(2, 3), out_axis=(1,), batch_axis=(0,)), weight_decay_scale=None)
+State: model/sampler/decoder/transformer/repeat/layer/self_attention/norm/scale=bfloat16((32, 4096)) mesh_axes=ParameterSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None, initializer=None, factorization=None, fan_axes=None, weight_decay_scale=None)
+State: learner/optimizer/0/count=int32(()) mesh_axes=TensorSpec(shape=(), dtype=dtype('int32'), mesh_axes=PartitionSpec(), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/emb/token_emb/weight=bfloat16((128256, 4096)) mesh_axes=TensorSpec(shape=[128256, 4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/lm_head/weight=bfloat16((128256, 4096)) mesh_axes=TensorSpec(shape=(128256, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/output_norm/scale=bfloat16((4096,)) mesh_axes=TensorSpec(shape=[4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None,), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight=bfloat16((32, 4096, 14336)) mesh_axes=TensorSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight=bfloat16((32, 4096, 14336)) mesh_axes=TensorSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/feed_forward/linear2/weight=bfloat16((32, 14336, 4096)) mesh_axes=TensorSpec(shape=(32, 14336, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, 'model', ('expert', 'fsdp', 'seq')), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/feed_forward/norm/scale=bfloat16((32, 4096)) mesh_axes=TensorSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight=bfloat16((32, 4096, 48, 128)) mesh_axes=TensorSpec(shape=(32, 4096, 48, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight=bfloat16((32, 4096, 32, 128)) mesh_axes=TensorSpec(shape=(32, 4096, 32, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None)
+State: learner/optimizer/0/mu/actor/decoder/transformer/repeat/layer/self_attention/norm/scale=bfloat16((32, 4096)) mesh_axes=TensorSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/emb/token_emb/weight=bfloat16((128256, 4096)) mesh_axes=TensorSpec(shape=[128256, 4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/lm_head/weight=bfloat16((128256, 4096)) mesh_axes=TensorSpec(shape=(128256, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec('model', ('expert', 'fsdp', 'seq')), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/output_norm/scale=bfloat16((4096,)) mesh_axes=TensorSpec(shape=[4096], dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None,), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/feed_forward/linear1_0/weight=bfloat16((32, 4096, 14336)) mesh_axes=TensorSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/feed_forward/linear1_1/weight=bfloat16((32, 4096, 14336)) mesh_axes=TensorSpec(shape=(32, 4096, 14336), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model'), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/feed_forward/linear2/weight=bfloat16((32, 14336, 4096)) mesh_axes=TensorSpec(shape=(32, 14336, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, 'model', ('expert', 'fsdp', 'seq')), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/feed_forward/norm/scale=bfloat16((32, 4096)) mesh_axes=TensorSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/self_attention/attention/i_proj/i_proj/qkv_proj/weight=bfloat16((32, 4096, 48, 128)) mesh_axes=TensorSpec(shape=(32, 4096, 48, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/self_attention/attention/o_proj/weight=bfloat16((32, 4096, 32, 128)) mesh_axes=TensorSpec(shape=(32, 4096, 32, 128), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, ('expert', 'fsdp', 'seq'), 'model', None), memory_kind=None)
+State: learner/optimizer/0/nu/actor/decoder/transformer/repeat/layer/self_attention/norm/scale=bfloat16((32, 4096)) mesh_axes=TensorSpec(shape=(32, 4096), dtype=<class 'jax.numpy.bfloat16'>, mesh_axes=PartitionSpec(None, None), memory_kind=None)
+State: learner/optimizer/2/count=int32(()) mesh_axes=TensorSpec(shape=[], dtype=<class 'jax.numpy.int32'>, mesh_axes=PartitionSpec(), memory_kind=None)
+Training state size: 74.79 GiB
+Training state size (partitioned): 4.68 GiB
+Max training state size (partitioned): 4.68 GiB
+##########################################################%
+
+```
+
+## Training Metrics
+
+### Definition
+---
+
+#### 1. **`loss`** (Policy Gradient Objective)
+*   **Definition**: The overall composite objective minimized by the optimizer. It combines the negative GRPO surrogate policy loss (which pushes the Actor to produce higher-advantage tokens) and the KL divergence penalty.
+*   **Plain-Text Formula**:
+    `Loss = -(Average of [ Minimum( Ratio * Advantage, Clipped_Ratio * Advantage ) ]) + beta * KL_Divergence`
+*   **Intuition**: This is the "steering wheel" of your training. A smaller/more negative loss indicates the Actor model is successfully optimizing its parameters to maximize mathematical rewards while remaining safely constrained.
+
+---
+
+#### 2. **`kl_divergence`** (Kullback-Leibler Divergence)
+*   **Definition**: A statistical measure of how much the active Actor model's token probability distribution has drifted/diverged from the frozen, pre-trained Reference model's token probability distribution.
+*   **Plain-Text Formula**:
+    `KL_Divergence = Average of [ (Reference_Probability / Actor_Probability) - log(Reference_Probability / Actor_Probability) - 1 ]`
+*   **Intuition**: This measures the Actor's "deviation penalty." We want this to remain stable and small (e.g. `0.002 - 0.005`). If it surges too high, the model is "forgetting" its pre-trained knowledge or collapsing into gibberish to exploit the rewards.
+
+---
+
+#### 3. **`mean_advantage`**
+*   **Definition**: The average relative advantage score across all generations in the batch.
+*   **Plain-Text Formula**:
+    `Mean_Advantage = (Sum of all Advantages in Batch) / (Total Number of Rollouts in Batch) = 0.0`
+*   **Intuition**: Because GRPO computes relative advantages by Z-score normalizing the rewards *inside* each sibling group, the above-average advantages perfectly cancel out the below-average advantages. Thus, this metric is **mathematically, strictly always exactly `0.0`** by design.
+
+---
+
+#### 4. **`mean_reward`** (Absolute Scoreboard Accuracy)
+*   **Definition**: The percentage of generated rollouts in the current training batch that successfully solved the math problem correctly and matched the ground-truth final answer (received a reward of `1.0`).
+*   **Plain-Text Formula**:
+    `Mean_Reward = (Number of Correct Rollouts in Batch) / (Total Number of Rollouts in Batch)`
+*   **Intuition**: This is the **absolute scoreboard** showing how smart your model is in the real world. A value of `0.714` means exactly **71.4% of all math questions solved in this batch were completely correct.**
+
+---
+
+#### 5. **`std_advantage`** (The Learning Signal Contrast)
+*   **Definition**: The standard deviation (the spread/variance) of the relative advantages. It measures the **strength and presence of contrast** inside your training groups.
+*   **Plain-Text Formula**:
+    `Std_Advantage = Standard_Deviation(Advantages_in_Batch)`
+*   **Intuition**: Think of this as the **learning signal strength**.
+    *   If it is positive ($>0.0$): It confirms that in some groups, some siblings were correct and others were incorrect. This **contrast** provides a strong active gradient signal to the Actor model.
+    *   If it were $0.0$: All siblings got the exact same reward (no contrast), and the model would learn nothing.
+
+
+
+### Step Time Calculation
+To calculate the average step time across the entire range from Step 1 to Step 1000, I used the total wall-clock time elapsed.
+
+#### Overall Average Calculation
+
+The training run started at **2026-05-20 22:18:12** ([apple rl grpo decouple...](https://paste.googleplex.com/5465377663483904?content_ref=2026+05+20t22+18+12+092271991z)) and reached Step 1000 at **2026-05-23 09:13:19** ([apple rl grpo decouple...](https://paste.googleplex.com/5465377663483904?content_ref=2026+05+23t09+13+19+974985949z)).
+
+*   **Total Elapsed Time:** 2 days, 10 hours, 55 minutes, and 7 seconds ($212,107.88$ seconds).
+*   **Total Steps Completed:** 999 steps (from Step 1 to Step 1000).
+*   **Average Step Time (Wall-Clock):** **3.54 minutes per step** (or $212.32$ seconds).
+
+#### Comparison to Active Training Time
+This "raw" average includes all system overhead and downtime (such as the ~1.5-hour gaps between steps 100-110 and 130-140).
+
+| Metric | Duration (Minutes) | Duration (Seconds) |
+| :--- | :---: | :---: |
+| **Wall-Clock Average (incl. gaps)** | **3.54** | **212.32** |
+| Active Training Average (excl. gaps) | 3.45 | 206.94 |
+
+The small difference (approx. 5 seconds) between the wall-clock average and the active average indicates that while there were some process restarts, the training run was largely consistent throughout the 1000 steps. For example, the gap between Step 790 (20:02:28) and Step 800 (21:50:22) lasted approximately 107 minutes for 10 steps, averaging 10.7 minutes/step. This segment was excluded form the calculation.
+
+### Metrics Log
+| timestamp | message |
+| :--- | :--- |
+| 2026-05-20T22:18:12.092271991Z | grpo_trainer process   0 step        1] loss=-3.457978e-05 aux={'kl_divergence': 0.00066375732421875, 'loss': -3.457978164078668e-05, 'mean_advantage': 0.0, 'mean_reward': 0.68359375, 'std_advantage': 0.36970269680023193} |
+| 2026-05-20T22:21:14.885783794Z | grpo_trainer process   0 step        2] loss=0.00028741112 aux={'kl_divergence': 0.007476806640625, 'loss': 0.00028741112328134477, 'mean_advantage': 0.0, 'mean_reward': 0.70703125, 'std_advantage': 0.4001386761665344} |
+| 2026-05-20T22:24:01.066044014Z | grpo_trainer process   0 step        3] loss=0.00115081 aux={'kl_divergence': 0.028076171875, 'loss': 0.0011508100433275104, 'mean_advantage': 0.0, 'mean_reward': 0.7734375, 'std_advantage': 0.4049890339374542} |
+| 2026-05-20T22:26:45.383707212Z | grpo_trainer process   0 step        4] loss=0.0013424202 aux={'kl_divergence': 0.03369140625, 'loss': 0.001342420233413577, 'mean_advantage': 0.0, 'mean_reward': 0.81640625, 'std_advantage': 0.3247136175632477} |
+| 2026-05-20T22:29:27.062902737Z | grpo_trainer process   0 step        5] loss=0.0015679549 aux={'kl_divergence': 0.03955078125, 'loss': 0.001567954896017909, 'mean_advantage': 0.0, 'mean_reward': 0.79296875, 'std_advantage': 0.36970269680023193} |
+| 2026-05-20T22:43:12.758484698Z | grpo_trainer process   0 step       10] loss=0.0018605773 aux={'kl_divergence': 0.046875, 'loss': 0.0018605772638693452, 'mean_advantage': 0.0, 'mean_reward': 0.78125, 'std_advantage': 0.34227824211120605} |
+| 2026-05-20T23:11:27.154809090Z | grpo_trainer process   0 step       20] loss=0.0017447168 aux={'kl_divergence': 0.04345703125, 'loss': 0.0017447167774662375, 'mean_advantage': 0.0, 'mean_reward': 0.85546875, 'std_advantage': 0.3124558627605438} |
+| 2026-05-20T23:40:07.707870475Z | grpo_trainer process   0 step       30] loss=0.0014684689 aux={'kl_divergence': 0.038818359375, 'loss': 0.0014684689231216908, 'mean_advantage': 0.0, 'mean_reward': 0.80078125, 'std_advantage': 0.34793609380722046} |
+| 2026-05-21T00:09:13.667881221Z | grpo_trainer process   0 step       40] loss=0.002723298 aux={'kl_divergence': 0.06787109375, 'loss': 0.0027232980355620384, 'mean_advantage': 0.0, 'mean_reward': 0.703125, 'std_advantage': 0.34227821230888367} |
+| 2026-05-21T00:38:07.962246864Z | grpo_trainer process   0 step       50] loss=0.002641279 aux={'kl_divergence': 0.06640625, 'loss': 0.0026412790175527334, 'mean_advantage': 0.0, 'mean_reward': 0.74609375, 'std_advantage': 0.4001387059688568} |
+| 2026-05-21T01:06:50.863663753Z | grpo_trainer process   0 step       60] loss=0.0026504158 aux={'kl_divergence': 0.06640625, 'loss': 0.0026504157576709986, 'mean_advantage': 0.0, 'mean_reward': 0.7734375, 'std_advantage': 0.34227821230888367} |
+| 2026-05-21T01:34:48.522336833Z | grpo_trainer process   0 step       70] loss=0.0018068241 aux={'kl_divergence': 0.044921875, 'loss': 0.0018068241188302636, 'mean_advantage': 0.0, 'mean_reward': 0.81640625, 'std_advantage': 0.3124558627605438} |
+| 2026-05-21T02:02:55.233805252Z | grpo_trainer process   0 step       80] loss=0.0013492543 aux={'kl_divergence': 0.03369140625, 'loss': 0.0013492542784661055, 'mean_advantage': 0.0, 'mean_reward': 0.8515625, 'std_advantage': 0.2931095361709595} |
+| 2026-05-21T02:31:21.249166640Z | grpo_trainer process   0 step       90] loss=0.0015166044 aux={'kl_divergence': 0.037353515625, 'loss': 0.0015166044468060136, 'mean_advantage': 0.0, 'mean_reward': 0.84765625, 'std_advantage': 0.2996971309185028} |
+| 2026-05-21T02:59:34.445144393Z | grpo_trainer process   0 step      100] loss=0.0020650243 aux={'kl_divergence': 0.0517578125, 'loss': 0.0020650243386626244, 'mean_advantage': 0.0, 'mean_reward': 0.80859375, 'std_advantage': 0.3247136175632477} |
+| 2026-05-21T04:29:48.562039133Z | grpo_trainer process   0 step      110] loss=0.0010812202 aux={'kl_divergence': 0.0274658203125, 'loss': 0.0010812202235683799, 'mean_advantage': 0.0, 'mean_reward': 0.76171875, 'std_advantage': 0.34793609380722046} |
+| 2026-05-21T04:56:44.706656632Z | grpo_trainer process   0 step      120] loss=0.0010059193 aux={'kl_divergence': 0.0255126953125, 'loss': 0.0010059193009510636, 'mean_advantage': 0.0, 'mean_reward': 0.7890625, 'std_advantage': 0.3186436891555786} |
+| 2026-05-21T05:23:43.210760675Z | grpo_trainer process   0 step      130] loss=0.0020528017 aux={'kl_divergence': 0.051025390625, 'loss': 0.002052801661193371, 'mean_advantage': 0.0, 'mean_reward': 0.73828125, 'std_advantage': 0.33652523159980774} |
+| 2026-05-21T06:53:57.668558349Z | grpo_trainer process   0 step      140] loss=0.001375706 aux={'kl_divergence': 0.03466796875, 'loss': 0.0013757060514762998, 'mean_advantage': 0.0, 'mean_reward': 0.80859375, 'std_advantage': 0.35898441076278687} |
+| 2026-05-21T07:25:51.180543689Z | grpo_trainer process   0 step      150] loss=0.0012500313 aux={'kl_divergence': 0.031005859375, 'loss': 0.0012500312877818942, 'mean_advantage': 0.0, 'mean_reward': 0.8359375, 'std_advantage': 0.34227821230888367} |
+| 2026-05-21T07:57:43.633816818Z | grpo_trainer process   0 step      160] loss=0.0011262903 aux={'kl_divergence': 0.0281982421875, 'loss': 0.0011262902989983559, 'mean_advantage': 0.0, 'mean_reward': 0.80078125, 'std_advantage': 0.3124558627605438} |
+| 2026-05-21T08:51:38.209021221Z | grpo_trainer process   0 step      170] loss=0.0018288587 aux={'kl_divergence': 0.04638671875, 'loss': 0.0018288587452843785, 'mean_advantage': 0.0, 'mean_reward': 0.8515625, 'std_advantage': 0.3061429262161255} |
+| 2026-05-21T09:24:02.841561292Z | grpo_trainer process   0 step      180] loss=0.0016368012 aux={'kl_divergence': 0.04150390625, 'loss': 0.001636801171116531, 'mean_advantage': 0.0, 'mean_reward': 0.86328125, 'std_advantage': 0.32471364736557007} |
+| 2026-05-21T09:56:26.578846432Z | grpo_trainer process   0 step      190] loss=0.00083456 aux={'kl_divergence': 0.021240234375, 'loss': 0.0008345600217580795, 'mean_advantage': 0.0, 'mean_reward': 0.8125, 'std_advantage': 0.35350343585014343} |
+| 2026-05-21T10:28:49.752072669Z | grpo_trainer process   0 step      200] loss=0.0008566636 aux={'kl_divergence': 0.021484375, 'loss': 0.0008566636242903769, 'mean_advantage': 0.0, 'mean_reward': 0.859375, 'std_advantage': 0.3061429262161255} |
+| 2026-05-21T11:00:41.725593516Z | grpo_trainer process   0 step      210] loss=0.0011084096 aux={'kl_divergence': 0.027587890625, 'loss': 0.0011084096040576696, 'mean_advantage': 0.0, 'mean_reward': 0.7890625, 'std_advantage': 0.33067217469215393} |
+| 2026-05-21T11:33:03.217026791Z | grpo_trainer process   0 step      220] loss=0.0014873646 aux={'kl_divergence': 0.037109375, 'loss': 0.001487364643253386, 'mean_advantage': 0.0, 'mean_reward': 0.83984375, 'std_advantage': 0.31245583295822144} |
+| 2026-05-21T12:05:03.160119936Z | grpo_trainer process   0 step      230] loss=0.0015340311 aux={'kl_divergence': 0.038818359375, 'loss': 0.0015340311219915748, 'mean_advantage': 0.0, 'mean_reward': 0.80078125, 'std_advantage': 0.35898441076278687} |
+| 2026-05-21T12:37:30.442265416Z | grpo_trainer process   0 step      240] loss=0.0011927191 aux={'kl_divergence': 0.0294189453125, 'loss': 0.0011927190935239196, 'mean_advantage': 0.0, 'mean_reward': 0.89453125, 'std_advantage': 0.2723926603794098} |
+| 2026-05-21T13:09:53.947645781Z | grpo_trainer process   0 step      250] loss=0.0010791621 aux={'kl_divergence': 0.026611328125, 'loss': 0.0010791621170938015, 'mean_advantage': 0.0, 'mean_reward': 0.83984375, 'std_advantage': 0.2576576769351959} |
+| 2026-05-21T13:42:08.514955041Z | grpo_trainer process   0 step      260] loss=0.00078981195 aux={'kl_divergence': 0.019287109375, 'loss': 0.0007898119511082768, 'mean_advantage': 0.0, 'mean_reward': 0.80859375, 'std_advantage': 0.28637051582336426} |
+| 2026-05-21T14:14:29.498439384Z | grpo_trainer process   0 step      270] loss=0.0013654947 aux={'kl_divergence': 0.031494140625, 'loss': 0.0013654946815222502, 'mean_advantage': 0.0, 'mean_reward': 0.84375, 'std_advantage': 0.3186436593532562} |
+| 2026-05-21T14:46:50.348814242Z | grpo_trainer process   0 step      280] loss=0.0010428817 aux={'kl_divergence': 0.0255126953125, 'loss': 0.0010428817477077246, 'mean_advantage': 0.0, 'mean_reward': 0.8515625, 'std_advantage': 0.3061429262161255} |
+| 2026-05-21T15:19:07.077788536Z | grpo_trainer process   0 step      290] loss=0.0018607009 aux={'kl_divergence': 0.0458984375, 'loss': 0.0018607008969411254, 'mean_advantage': 0.0, 'mean_reward': 0.88671875, 'std_advantage': 0.2576576769351959} |
+| 2026-05-21T15:51:30.866416636Z | grpo_trainer process   0 step      300] loss=0.0011701463 aux={'kl_divergence': 0.02978515625, 'loss': 0.0011701462790369987, 'mean_advantage': 0.0, 'mean_reward': 0.8203125, 'std_advantage': 0.3186436891555786} |
+| 2026-05-21T16:56:48.579458039Z | grpo_trainer process   0 step      310] loss=0.0018503338 aux={'kl_divergence': 0.04638671875, 'loss': 0.0018503337632864714, 'mean_advantage': 0.0, 'mean_reward': 0.82421875, 'std_advantage': 0.28637051582336426} |
+| 2026-05-21T17:50:57.495902099Z | grpo_trainer process   0 step      320] loss=0.0020006076 aux={'kl_divergence': 0.05029296875, 'loss': 0.0020006075501441956, 'mean_advantage': 0.0, 'mean_reward': 0.734375, 'std_advantage': 0.29310956597328186} |
+| 2026-05-21T18:22:49.187300548Z | grpo_trainer process   0 step      330] loss=0.0018963539 aux={'kl_divergence': 0.047607421875, 'loss': 0.001896353904157877, 'mean_advantage': 0.0, 'mean_reward': 0.80078125, 'std_advantage': 0.33652520179748535} |
+| 2026-05-21T18:54:24.922694855Z | grpo_trainer process   0 step      340] loss=0.0054456657 aux={'kl_divergence': 0.1357421875, 'loss': 0.005445665679872036, 'mean_advantage': 0.0, 'mean_reward': 0.79296875, 'std_advantage': 0.3247136175632477} |
+| 2026-05-21T19:25:55.882906259Z | grpo_trainer process   0 step      350] loss=0.007454818 aux={'kl_divergence': 0.1865234375, 'loss': 0.0074548181146383286, 'mean_advantage': 0.0, 'mean_reward': 0.8203125, 'std_advantage': 0.33067217469215393} |
+| 2026-05-21T19:57:51.066915109Z | grpo_trainer process   0 step      360] loss=0.0056595854 aux={'kl_divergence': 0.1416015625, 'loss': 0.005659585352987051, 'mean_advantage': 0.0, 'mean_reward': 0.84375, 'std_advantage': 0.27946901321411133} |
+| 2026-05-21T20:30:01.532842459Z | grpo_trainer process   0 step      370] loss=0.005690878 aux={'kl_divergence': 0.14453125, 'loss': 0.005690877791494131, 'mean_advantage': 0.0, 'mean_reward': 0.82421875, 'std_advantage': 0.3124558627605438} |
+| 2026-05-21T21:01:54.699033834Z | grpo_trainer process   0 step      380] loss=0.004170566 aux={'kl_divergence': 0.1826171875, 'loss': 0.004170565865933895, 'mean_advantage': 0.0, 'mean_reward': 0.82421875, 'std_advantage': 0.33652520179748535} |
+| 2026-05-21T21:33:41.274742246Z | grpo_trainer process   0 step      390] loss=0.0031784268 aux={'kl_divergence': 0.07958984375, 'loss': 0.0031784267630428076, 'mean_advantage': 0.0, 'mean_reward': 0.83984375, 'std_advantage': 0.3247135877609253} |
+| 2026-05-21T22:05:42.243565384Z | grpo_trainer process   0 step      400] loss=0.0021257214 aux={'kl_divergence': 0.051513671875, 'loss': 0.002125721424818039, 'mean_advantage': 0.0, 'mean_reward': 0.765625, 'std_advantage': 0.3749469816684723} |
+| 2026-05-21T22:37:48.809997051Z | grpo_trainer process   0 step      410] loss=0.0030547904 aux={'kl_divergence': 0.076171875, 'loss': 0.0030547904316335917, 'mean_advantage': 0.0, 'mean_reward': 0.8125, 'std_advantage': 0.33067217469215393} |
+| 2026-05-21T23:09:55.881353340Z | grpo_trainer process   0 step      420] loss=0.0028431346 aux={'kl_divergence': 0.07275390625, 'loss': 0.002843134570866823, 'mean_advantage': 0.0, 'mean_reward': 0.828125, 'std_advantage': 0.27946901321411133} |
+| 2026-05-21T23:41:53.512144675Z | grpo_trainer process   0 step      430] loss=0.003304979 aux={'kl_divergence': 0.08154296875, 'loss': 0.0033049790654331446, 'mean_advantage': 0.0, 'mean_reward': 0.7890625, 'std_advantage': 0.33067217469215393} |
+| 2026-05-22T00:13:55.887190536Z | grpo_trainer process   0 step      440] loss=0.0039181598 aux={'kl_divergence': 0.09765625, 'loss': 0.003918159753084183, 'mean_advantage': 0.0, 'mean_reward': 0.83203125, 'std_advantage': 0.2723926901817322} |
+| 2026-05-22T00:45:44.122941486Z | grpo_trainer process   0 step      450] loss=0.0046657296 aux={'kl_divergence': 0.1162109375, 'loss': 0.0046657295897603035, 'mean_advantage': 0.0, 'mean_reward': 0.8359375, 'std_advantage': 0.3186436593532562} |
+| 2026-05-22T01:17:53.695116630Z | grpo_trainer process   0 step      460] loss=0.005848777 aux={'kl_divergence': 0.1455078125, 'loss': 0.005848777014762163, 'mean_advantage': 0.0, 'mean_reward': 0.83984375, 'std_advantage': 0.24202725291252136} |
+| 2026-05-22T01:50:10.674041534Z | grpo_trainer process   0 step      470] loss=0.0055388883 aux={'kl_divergence': 0.138671875, 'loss': 0.0055388882756233215, 'mean_advantage': 0.0, 'mean_reward': 0.82421875, 'std_advantage': 0.2723926901817322} |
+| 2026-05-22T02:22:26.004694592Z | grpo_trainer process   0 step      480] loss=0.005008635 aux={'kl_divergence': 0.1259765625, 'loss': 0.005008635111153126, 'mean_advantage': 0.0, 'mean_reward': 0.83203125, 'std_advantage': 0.28637048602104187} |
+| 2026-05-22T02:54:50.519501962Z | grpo_trainer process   0 step      490] loss=0.0058812983 aux={'kl_divergence': 0.1494140625, 'loss': 0.005881298333406448, 'mean_advantage': 0.0, 'mean_reward': 0.84375, 'std_advantage': 0.3061429262161255} |
+| 2026-05-22T03:27:06.446059476Z | grpo_trainer process   0 step      500] loss=0.0019979917 aux={'kl_divergence': 0.05029296875, 'loss': 0.0019979916978627443, 'mean_advantage': 0.0, 'mean_reward': 0.83203125, 'std_advantage': 0.31245583295822144} |
+| 2026-05-22T03:59:24.588697566Z | grpo_trainer process   0 step      510] loss=0.0009672041 aux={'kl_divergence': 0.02392578125, 'loss': 0.0009672041051089764, 'mean_advantage': 0.0, 'mean_reward': 0.82421875, 'std_advantage': 0.33652523159980774} |
+| 2026-05-22T04:31:20.127201852Z | grpo_trainer process   0 step      520] loss=0.0011656838 aux={'kl_divergence': 0.0303955078125, 'loss': 0.0011656838469207287, 'mean_advantage': 0.0, 'mean_reward': 0.83203125, 'std_advantage': 0.2723926901817322} |
+| 2026-05-22T05:03:12.649262331Z | grpo_trainer process   0 step      530] loss=0.001120667 aux={'kl_divergence': 0.0281982421875, 'loss': 0.0011206669732928276, 'mean_advantage': 0.0, 'mean_reward': 0.84765625, 'std_advantage': 0.31245583295822144} |
+| 2026-05-22T05:35:17.823372914Z | grpo_trainer process   0 step      540] loss=0.0021542164 aux={'kl_divergence': 0.0546875, 'loss': 0.0021542164031416178, 'mean_advantage': 0.0, 'mean_reward': 0.8515625, 'std_advantage': 0.27946901321411133} |
+| 2026-05-22T06:07:31.346706271Z | grpo_trainer process   0 step      550] loss=0.005200909 aux={'kl_divergence': 0.1298828125, 'loss': 0.005200908984988928, 'mean_advantage': 0.0, 'mean_reward': 0.890625, 'std_advantage': 0.29310956597328186} |
+| 2026-05-22T06:39:36.244942006Z | grpo_trainer process   0 step      560] loss=0.008610529 aux={'kl_divergence': 0.21484375, 'loss': 0.008610528893768787, 'mean_advantage': 0.0, 'mean_reward': 0.79296875, 'std_advantage': 0.31245583295822144} |
+| 2026-05-22T07:11:33.924264235Z | grpo_trainer process   0 step      570] loss=0.003486838 aux={'kl_divergence': 0.0908203125, 'loss': 0.0034868379589170218, 'mean_advantage': 0.0, 'mean_reward': 0.8671875, 'std_advantage': 0.3061429560184479} |
+| 2026-05-22T07:43:41.869713054Z | grpo_trainer process   0 step      580] loss=0.0017850895 aux={'kl_divergence': 0.11376953125, 'loss': 0.0017850894946604967, 'mean_advantage': 0.0, 'mean_reward': 0.82421875, 'std_advantage': 0.3247136175632477} |
+| 2026-05-22T08:15:38.562563168Z | grpo_trainer process   0 step      590] loss=-0.010442441 aux={'kl_divergence': 0.5, 'loss': -0.010442441329360008, 'mean_advantage': 0.0, 'mean_reward': 0.7734375, 'std_advantage': 0.33067217469215393} |
+| 2026-05-22T08:47:50.362776123Z | grpo_trainer process   0 step      600] loss=0.034464348 aux={'kl_divergence': 1.7890625, 'loss': 0.03446434810757637, 'mean_advantage': 0.0, 'mean_reward': 0.78515625, 'std_advantage': 0.34793609380722046} |
+| 2026-05-22T09:19:51.979916643Z | grpo_trainer process   0 step      610] loss=-0.012390678 aux={'kl_divergence': 0.6015625, 'loss': -0.012390677817165852, 'mean_advantage': 0.0, 'mean_reward': 0.76953125, 'std_advantage': 0.3124558627605438} |
+| 2026-05-22T10:34:23.464028301Z | grpo_trainer process   0 step      620] loss=0.081923306 aux={'kl_divergence': 3.5, 'loss': 0.08192330598831177, 'mean_advantage': 0.0, 'mean_reward': 0.7890625, 'std_advantage': 0.3643829822540283} |
+| 2026-05-22T11:07:01.636018161Z | grpo_trainer process   0 step      630] loss=0.09963063 aux={'kl_divergence': 4.40625, 'loss': 0.09963063150644302, 'mean_advantage': 0.0, 'mean_reward': 0.73046875, 'std_advantage': 0.40978196263313293} |
+| 2026-05-22T11:39:36.538371633Z | grpo_trainer process   0 step      640] loss=0.18580464 aux={'kl_divergence': 5.53125, 'loss': 0.18580463528633118, 'mean_advantage': 0.0, 'mean_reward': 0.85546875, 'std_advantage': 0.2996971011161804} |
+| 2026-05-22T12:12:03.783374015Z | grpo_trainer process   0 step      650] loss=0.020792492 aux={'kl_divergence': 2.71875, 'loss': 0.020792491734027863, 'mean_advantage': 0.0, 'mean_reward': 0.6875, 'std_advantage': 0.4145195186138153} |
+| 2026-05-22T12:45:01.018651464Z | grpo_trainer process   0 step      660] loss=0.07614714 aux={'kl_divergence': 5.375, 'loss': 0.07614713907241821, 'mean_advantage': 0.0, 'mean_reward': 0.6640625, 'std_advantage': 0.459214448928833} |
+| 2026-05-22T13:17:35.197225585Z | grpo_trainer process   0 step      670] loss=-0.07165395 aux={'kl_divergence': 0.1953125, 'loss': -0.07165394723415375, 'mean_advantage': 0.0, 'mean_reward': 0.76953125, 'std_advantage': 0.36970269680023193} |
+| 2026-05-22T13:50:08.690478521Z | grpo_trainer process   0 step      680] loss=-0.050928295 aux={'kl_divergence': 0.291015625, 'loss': -0.05092829465866089, 'mean_advantage': 0.0, 'mean_reward': 0.77734375, 'std_advantage': 0.34793609380722046} |
+| 2026-05-22T14:22:37.831674367Z | grpo_trainer process   0 step      690] loss=-0.090814 aux={'kl_divergence': 0.28125, 'loss': -0.0908140018582344, 'mean_advantage': 0.0, 'mean_reward': 0.671875, 'std_advantage': 0.4145195186138153} |
+| 2026-05-22T14:55:14.076143674Z | grpo_trainer process   0 step      700] loss=-0.06022806 aux={'kl_divergence': 0.1484375, 'loss': -0.06022806093096733, 'mean_advantage': 0.0, 'mean_reward': 0.72265625, 'std_advantage': 0.39025720953941345} |
+| 2026-05-22T15:27:50.283085825Z | grpo_trainer process   0 step      710] loss=-0.06994404 aux={'kl_divergence': 0.26171875, 'loss': -0.06994403898715973, 'mean_advantage': 0.0, 'mean_reward': 0.70703125, 'std_advantage': 0.4001386761665344} |
+| 2026-05-22T16:00:01.060380575Z | grpo_trainer process   0 step      720] loss=-0.09920842 aux={'kl_divergence': 0.431640625, 'loss': -0.09920842200517654, 'mean_advantage': 0.0, 'mean_reward': 0.5859375, 'std_advantage': 0.4238356947898865} |
+| 2026-05-22T16:32:26.879066228Z | grpo_trainer process   0 step      730] loss=-0.10878732 aux={'kl_divergence': 0.44921875, 'loss': -0.10878732055425644, 'mean_advantage': 0.0, 'mean_reward': 0.6875, 'std_advantage': 0.4049890339374542} |
+| 2026-05-22T17:04:38.653022444Z | grpo_trainer process   0 step      740] loss=-0.075865075 aux={'kl_divergence': 0.2001953125, 'loss': -0.07586507499217987, 'mean_advantage': 0.0, 'mean_reward': 0.7734375, 'std_advantage': 0.3852214515209198} |
+| 2026-05-22T17:37:03.042670263Z | grpo_trainer process   0 step      750] loss=-0.06815426 aux={'kl_divergence': 0.33203125, 'loss': -0.06815426051616669, 'mean_advantage': 0.0, 'mean_reward': 0.72265625, 'std_advantage': 0.4192034602165222} |
+| 2026-05-22T17:53:16.399139616Z | grpo_trainer process   0 step      750] loss=-0.069291085 aux={'kl_divergence': 0.50390625, 'loss': -0.06929108500480652, 'mean_advantage': 0.0, 'mean_reward': 0.73046875, 'std_advantage': 0.4001387059688568} |
+| 2026-05-22T18:25:22.927145354Z | grpo_trainer process   0 step      760] loss=-0.0668161 aux={'kl_divergence': 0.279296875, 'loss': -0.06681609898805618, 'mean_advantage': 0.0, 'mean_reward': 0.81640625, 'std_advantage': 0.36970269680023193} |
+| 2026-05-22T18:57:32.424465497Z | grpo_trainer process   0 step      770] loss=-0.0634951 aux={'kl_divergence': 0.13671875, 'loss': -0.06349509954452515, 'mean_advantage': 0.0, 'mean_reward': 0.7421875, 'std_advantage': 0.3643829822540283} |
+| 2026-05-22T19:30:23.105309243Z | grpo_trainer process   0 step      780] loss=-0.14850381 aux={'kl_divergence': 0.439453125, 'loss': -0.14850381016731262, 'mean_advantage': 0.0, 'mean_reward': 0.5234375, 'std_advantage': 0.45063015818595886} |
+| 2026-05-22T20:02:28.565239559Z | grpo_trainer process   0 step      790] loss=-0.124386005 aux={'kl_divergence': 0.208984375, 'loss': -0.1243860051035881, 'mean_advantage': 0.0, 'mean_reward': 0.7265625, 'std_advantage': 0.4418792724609375} |
+| 2026-05-22T21:50:22.116266570Z | grpo_trainer process   0 step      800] loss=-0.13364542 aux={'kl_divergence': 0.2578125, 'loss': -0.1336454153060913, 'mean_advantage': 0.0, 'mean_reward': 0.6640625, 'std_advantage': 0.45063021779060364} |
+| 2026-05-22T22:56:24.496360051Z | grpo_trainer process   0 step      810] loss=-0.14158413 aux={'kl_divergence': 0.38671875, 'loss': -0.1415841281414032, 'mean_advantage': 0.0, 'mean_reward': 0.6015625, 'std_advantage': 0.4329514801502228} |
+| 2026-05-22T23:28:32.510353636Z | grpo_trainer process   0 step      820] loss=-0.066071026 aux={'kl_divergence': 0.1533203125, 'loss': -0.0660710260272026, 'mean_advantage': 0.0, 'mean_reward': 0.7109375, 'std_advantage': 0.3852214515209198} |
+| 2026-05-23T00:00:49.963098298Z | grpo_trainer process   0 step      830] loss=-0.077516325 aux={'kl_divergence': 0.177734375, 'loss': -0.07751632481813431, 'mean_advantage': 0.0, 'mean_reward': 0.74609375, 'std_advantage': 0.36970269680023193} |
+| 2026-05-23T00:33:06.136014391Z | grpo_trainer process   0 step      840] loss=-0.073309146 aux={'kl_divergence': 0.2333984375, 'loss': -0.07330914586782455, 'mean_advantage': 0.0, 'mean_reward': 0.6484375, 'std_advantage': 0.3749469816684723} |
+| 2026-05-23T01:05:44.310713186Z | grpo_trainer process   0 step      850] loss=-0.12693672 aux={'kl_divergence': 0.41015625, 'loss': -0.12693671882152557, 'mean_advantage': 0.0, 'mean_reward': 0.57421875, 'std_advantage': 0.428417831659317} |
+| 2026-05-23T01:38:14.544007316Z | grpo_trainer process   0 step      860] loss=-0.06829094 aux={'kl_divergence': 0.1904296875, 'loss': -0.06829094141721725, 'mean_advantage': 0.0, 'mean_reward': 0.7578125, 'std_advantage': 0.3422781825065613} |
+| 2026-05-23T02:10:53.600397443Z | grpo_trainer process   0 step      870] loss=-0.09320154 aux={'kl_divergence': 0.251953125, 'loss': -0.09320154041051865, 'mean_advantage': 0.0, 'mean_reward': 0.734375, 'std_advantage': 0.4049890339374542} |
+| 2026-05-23T02:43:09.556622928Z | grpo_trainer process   0 step      880] loss=-0.12533228 aux={'kl_divergence': 0.2353515625, 'loss': -0.1253322809934616, 'mean_advantage': 0.0, 'mean_reward': 0.66796875, 'std_advantage': 0.4549425542354584} |
+| 2026-05-23T03:16:07.432820635Z | grpo_trainer process   0 step      890] loss=-0.094314456 aux={'kl_divergence': 0.265625, 'loss': -0.09431445598602295, 'mean_advantage': 0.0, 'mean_reward': 0.69921875, 'std_advantage': 0.4192034900188446} |
+| 2026-05-23T03:48:31.271703809Z | grpo_trainer process   0 step      900] loss=-0.07618472 aux={'kl_divergence': 0.27734375, 'loss': -0.0761847198009491, 'mean_advantage': 0.0, 'mean_reward': 0.7265625, 'std_advantage': 0.3952288329601288} |
+| 2026-05-23T04:20:56.618090038Z | grpo_trainer process   0 step      910] loss=-0.08086206 aux={'kl_divergence': 0.35546875, 'loss': -0.08086206018924713, 'mean_advantage': 0.0, 'mean_reward': 0.7109375, 'std_advantage': 0.4145195186138153} |
+| 2026-05-23T04:53:11.031356898Z | grpo_trainer process   0 step      920] loss=-0.09914622 aux={'kl_divergence': 0.291015625, 'loss': -0.09914621710777283, 'mean_advantage': 0.0, 'mean_reward': 0.6875, 'std_advantage': 0.4238356947898865} |
+| 2026-05-23T05:25:25.436153684Z | grpo_trainer process   0 step      930] loss=-0.098998345 aux={'kl_divergence': 0.1494140625, 'loss': -0.09899834543466568, 'mean_advantage': 0.0, 'mean_reward': 0.7265625, 'std_advantage': 0.4049890339374542} |
+| 2026-05-23T05:57:59.276675037Z | grpo_trainer process   0 step      940] loss=-0.08310325 aux={'kl_divergence': 0.1826171875, 'loss': -0.083103246986866, 'mean_advantage': 0.0, 'mean_reward': 0.72265625, 'std_advantage': 0.36970269680023193} |
+| 2026-05-23T06:30:29.761157065Z | grpo_trainer process   0 step      950] loss=-0.050403107 aux={'kl_divergence': 0.23828125, 'loss': -0.050403106957674026, 'mean_advantage': 0.0, 'mean_reward': 0.78515625, 'std_advantage': 0.35898441076278687} |
+| 2026-05-23T07:02:57.012105371Z | grpo_trainer process   0 step      960] loss=-0.05283285 aux={'kl_divergence': 0.126953125, 'loss': -0.05283284932374954, 'mean_advantage': 0.0, 'mean_reward': 0.828125, 'std_advantage': 0.3422781825065613} |
+| 2026-05-23T07:35:29.761920602Z | grpo_trainer process   0 step      970] loss=-0.13346703 aux={'kl_divergence': 0.388671875, 'loss': -0.13346703350543976, 'mean_advantage': 0.0, 'mean_reward': 0.5234375, 'std_advantage': 0.4145195186138153} |
+| 2026-05-23T08:08:12.593694253Z | grpo_trainer process   0 step      980] loss=-0.09901131 aux={'kl_divergence': 0.1650390625, 'loss': -0.09901130944490433, 'mean_advantage': 0.0, 'mean_reward': 0.75390625, 'std_advantage': 0.4097820222377777} |
+| 2026-05-23T08:40:51.088112437Z | grpo_trainer process   0 step      990] loss=-0.08227306 aux={'kl_divergence': 0.185546875, 'loss': -0.08227305859327316, 'mean_advantage': 0.0, 'mean_reward': 0.7421875, 'std_advantage': 0.3852214515209198} |
+| 2026-05-23T09:13:19.974985949Z | grpo_trainer process   0 step     1000] loss=-0.0815361 aux={'kl_divergence': 0.2294921875, 'loss': -0.08153609931468964, 'mean_advantage': 0.0, 'mean_reward': 0.7109375, 'std_advantage': 0.3952288329601288} |

--- a/axlearn/tools/convert_gsm8k_to_tfrecord.py
+++ b/axlearn/tools/convert_gsm8k_to_tfrecord.py
@@ -33,7 +33,7 @@ flags.DEFINE_integer(
 )
 
 
-def serialize_sample(question: str, answer: str) -> bytes:
+def serialize_sample(question: str, answer: str, annotation: str, short_answer: str) -> bytes:
     """Packs problem strings variables into serializable Protobuf features."""
     example = tf.train.Example(
         features=tf.train.Features(
@@ -43,6 +43,12 @@ def serialize_sample(question: str, answer: str) -> bytes:
                 ),
                 "answer": tf.train.Feature(
                     bytes_list=tf.train.BytesList(value=[answer.encode("utf-8")])
+                ),
+                "annotation": tf.train.Feature(
+                    bytes_list=tf.train.BytesList(value=[annotation.encode("utf-8")])
+                ),
+                "short_answer": tf.train.Feature(
+                    bytes_list=tf.train.BytesList(value=[short_answer.encode("utf-8")])
                 ),
             }
         )
@@ -67,8 +73,12 @@ def convert_dataset(split: str, version_dir: str, num_shards: int) -> int:
     try:
         for item in data_stream.as_numpy_iterator():
             binary_record = serialize_sample(
-                question=item["question"].decode("utf-8"), answer=item["answer"].decode("utf-8")
+                question=item["question"].decode("utf-8"),
+                answer=item["answer"].decode("utf-8"),
+                annotation=item["annotation"].decode("utf-8"),
+                short_answer=item["short_answer"].decode("utf-8"),
             )
+
             assigned_shard = count % num_shards
             shard_writers[assigned_shard].write(binary_record)
             count += 1
@@ -118,6 +128,8 @@ def create_metadata_files(version_dir: str, num_shards: int, counts: dict):
                 "features": {
                     "question": {"type": "TENSOR", "tensor": {"shape": [], "dtype": "STRING"}},
                     "answer": {"type": "TENSOR", "tensor": {"shape": [], "dtype": "STRING"}},
+                    "annotation": {"type": "TENSOR", "tensor": {"shape": [], "dtype": "STRING"}},
+                    "short_answer": {"type": "TENSOR", "tensor": {"shape": [], "dtype": "STRING"}},
                 }
             },
         }
@@ -132,6 +144,8 @@ def verify_and_print_records(tfrecord_path: str, num_records: int):
     feature_description = {
         "question": tf.io.FixedLenFeature([], tf.string),
         "answer": tf.io.FixedLenFeature([], tf.string),
+        "annotation": tf.io.FixedLenFeature([], tf.string),
+        "short_answer": tf.io.FixedLenFeature([], tf.string),
     }
 
     build_dataset_fn = input_tf_data.tfrecord_dataset(
@@ -148,11 +162,15 @@ def verify_and_print_records(tfrecord_path: str, num_records: int):
         count += 1
         q_text = record["question"].numpy().decode("utf-8")
         a_text = record["answer"].numpy().decode("utf-8")
+        ann_text = record["annotation"].numpy().decode("utf-8")
+        sa_text = record["short_answer"].numpy().decode("utf-8")
 
-        print(f"\n[Record #{count}]")
-        print(f"Question:\n{q_text}")
-        print(f"Answer:\n{a_text}")
-        print("-" * 40)
+        logging.info("[eshenlog] [Record #%d]", count)
+        logging.info("[eshenlog] Question: %s", q_text)
+        logging.info("[eshenlog] Answer: %s", a_text)
+        logging.info("[eshenlog] Annotation: %s", ann_text)
+        logging.info("[eshenlog] Short Answer: %s", sa_text)
+        logging.info("[eshenlog] %s", "-" * 40)
 
 
 def main(_):

--- a/axlearn/tools/convert_gsm8k_to_tfrecord.py
+++ b/axlearn/tools/convert_gsm8k_to_tfrecord.py
@@ -1,0 +1,179 @@
+# Copyright © 2026 Apple Inc.
+
+"""Utility tool serializing GSM8K datasets into versioned structures natively."""
+
+
+import json
+import os
+
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from absl import app, flags, logging
+
+from axlearn.common import input_tf_data
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "output_dir",
+    None,
+    "Base storage directory or project bucket (e.g., data/tensorflow_datasets/)",
+    required=True,
+)
+flags.DEFINE_integer(
+    "verify_records",
+    3,
+    "Number of records to read back and verify after conversion",
+    required=False,
+)
+flags.DEFINE_integer(
+    "num_shards",
+    1,
+    "Number of file shards to split the dataset into for multi-host TPU compatibility",
+    required=False,
+)
+
+
+def serialize_sample(question: str, answer: str) -> bytes:
+    """Packs problem strings variables into serializable Protobuf features."""
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                "question": tf.train.Feature(
+                    bytes_list=tf.train.BytesList(value=[question.encode("utf-8")])
+                ),
+                "answer": tf.train.Feature(
+                    bytes_list=tf.train.BytesList(value=[answer.encode("utf-8")])
+                ),
+            }
+        )
+    )
+    return example.SerializeToString()
+
+
+def convert_dataset(split: str, version_dir: str, num_shards: int) -> int:
+    """Downloads original split and writes sharded TFRecords, returning total row count."""
+    logging.info("Fetching split data %s via TFDS...", split)
+    data_stream = tfds.load("gsm8k", split=split)
+
+    shard_writers = []
+    for s in range(num_shards):
+        target_filename = f"gsm8k-{split}.tfrecord-{s:05d}-of-{num_shards:05d}"
+        target_path = os.path.join(version_dir, target_filename)
+        shard_writers.append(tf.io.TFRecordWriter(target_path))
+
+    logging.info("Writing %d shards for split %s in directory %s", num_shards, split, version_dir)
+
+    count = 0
+    try:
+        for item in data_stream.as_numpy_iterator():
+            binary_record = serialize_sample(
+                question=item["question"].decode("utf-8"), answer=item["answer"].decode("utf-8")
+            )
+            assigned_shard = count % num_shards
+            shard_writers[assigned_shard].write(binary_record)
+            count += 1
+    finally:
+        for writer in shard_writers:
+            writer.close()
+
+    logging.info("Wrote out %d examples across %d shards for subset %s.", count, num_shards, split)
+    return count
+
+
+def create_metadata_files(version_dir: str, num_shards: int, counts: dict):
+    """Writes the dataset_info.json and features.json metadata dynamically using compiled counts."""
+    logging.info("Writing metadata JSON structures inside: %s", version_dir)
+
+    # Construct shards distribution profiles dynamically
+    def shard_distribution(total_count: int, shards: int) -> list:
+        base = total_count // shards
+        rem = total_count % shards
+        return [str(base + 1 if i < rem else base) for i in range(shards)]
+
+    dataset_info = {
+        "name": "gsm8k",
+        "version": "1.0.0",
+        "description": "Grade School Math 8k reasoning dataset, sharded for multi-host TPUs.",
+        "splits": [
+            {"name": "train", "shardLengths": shard_distribution(counts["train"], num_shards)},
+            {"name": "test", "shardLengths": shard_distribution(counts["test"], num_shards)},
+            {
+                "name": "train_socratic",
+                "shardLengths": shard_distribution(counts["train_socratic"], num_shards),
+            },
+            {
+                "name": "test_socratic",
+                "shardLengths": shard_distribution(counts["test_socratic"], num_shards),
+            },
+        ],
+    }
+
+    with tf.io.gfile.GFile(os.path.join(version_dir, "dataset_info.json"), "w") as f:
+        json.dump(dataset_info, f, indent=2)
+
+    features = {
+        "feature": {
+            "type": "STRUCT",
+            "struct": {
+                "features": {
+                    "question": {"type": "TENSOR", "tensor": {"shape": [], "dtype": "STRING"}},
+                    "answer": {"type": "TENSOR", "tensor": {"shape": [], "dtype": "STRING"}},
+                }
+            },
+        }
+    }
+
+    with tf.io.gfile.GFile(os.path.join(version_dir, "features.json"), "w") as f:
+        json.dump(features, f, indent=2)
+
+
+def verify_and_print_records(tfrecord_path: str, num_records: int):
+    """Reads back compiled tfrecord binary payloads natively to verify data integrity."""
+    feature_description = {
+        "question": tf.io.FixedLenFeature([], tf.string),
+        "answer": tf.io.FixedLenFeature([], tf.string),
+    }
+
+    build_dataset_fn = input_tf_data.tfrecord_dataset(
+        glob_path=tfrecord_path,
+        is_training=False,
+        shuffle_buffer_size=0,
+        features=feature_description,
+    )
+
+    parsed_dataset = build_dataset_fn()
+
+    count = 0
+    for record in parsed_dataset.take(num_records):
+        count += 1
+        q_text = record["question"].numpy().decode("utf-8")
+        a_text = record["answer"].numpy().decode("utf-8")
+
+        print(f"\n[Record #{count}]")
+        print(f"Question:\n{q_text}")
+        print(f"Answer:\n{a_text}")
+        print("-" * 40)
+
+
+def main(_):
+    version_dir = os.path.join(FLAGS.output_dir, "gsm8k", "1.0.0")
+    tf.io.gfile.makedirs(version_dir)
+
+    num_shards = FLAGS.num_shards
+
+    # Track exact counts dynamically during compilation loop
+    counts = {}
+    counts["train"] = convert_dataset("train", version_dir, num_shards)
+    counts["test"] = convert_dataset("test", version_dir, num_shards)
+    counts["train_socratic"] = convert_dataset("train_socratic", version_dir, num_shards)
+    counts["test_socratic"] = convert_dataset("test_socratic", version_dir, num_shards)
+
+    create_metadata_files(version_dir, num_shards, counts)
+
+    if FLAGS.verify_records > 0:
+        sample_shard = os.path.join(version_dir, "gsm8k-train.tfrecord-00000-of-*")
+        verify_and_print_records(sample_shard, FLAGS.verify_records)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/axlearn/tools/download_llama3_checkpoint.py
+++ b/axlearn/tools/download_llama3_checkpoint.py
@@ -1,0 +1,181 @@
+# Copyright © 2026 Apple Inc.
+
+"""Utility script downloading Hugging Face checkpoints, converting weights to Fuji JAX structures, and saving to GCS."""
+
+import copy
+import gc
+import os
+import threading
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tensorflow as tf
+import torch
+from absl import app, flags, logging
+from huggingface_hub import snapshot_download
+from transformers import LlamaForCausalLM
+
+# Monkey-patch axlearn's as_tensor recursively to support PyTorch BFloat16 conversion!
+from axlearn.common import param_converter
+from axlearn.common import utils as axlearn_utils
+from axlearn.common.checkpointer import TensorStoreStateStorage
+from axlearn.experiments.text.gpt import fuji
+
+_orig_as_tensor = axlearn_utils.as_tensor
+
+
+def _patched_as_tensor(x):
+    if isinstance(x, torch.Tensor) and x.dtype == torch.bfloat16:
+        return jnp.asarray(x.detach().cpu().to(torch.float32).numpy())
+    return _orig_as_tensor(x)
+
+
+axlearn_utils.as_tensor = _patched_as_tensor
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "model_id", "meta-llama/Llama-3.2-1B", "Hugging Face model identifier repo path", required=False
+)
+
+flags.DEFINE_string(
+    "model_size", "1B", "Fuji target model size (test, 1B, 3B, 7B, 70B)", required=False
+)
+flags.DEFINE_string(
+    "output_dir",
+    None,
+    "Destination GCS Bucket path or local write folder for JAX checkpoint",
+    required=True,
+)
+
+
+def download_hf_model(model_id: str) -> str:
+    """Downloads PyTorch model checkpoints from Hugging Face Hub."""
+    logging.info("Starting download for Hugging Face model: %s", model_id)
+    local_dir = snapshot_download(
+        repo_id=model_id,
+        ignore_patterns=["*.msgpack", "*.h5", "*.ot"],
+    )
+    logging.info("Model checkpoint successfully downloaded locally to: %s", local_dir)
+    return local_dir
+
+
+def monitor_upload_progress(step_dir: str, total_expected_files: int, stop_event: threading.Event):
+    """Polls the GCS output folder recursively to count successfully written files."""
+    logging.info("Starting GCS upload progress monitor thread...")
+
+    while not stop_event.is_set():
+        try:
+            gda_dir = os.path.join(step_dir, "gda")
+            file_count = 0
+            if tf.io.gfile.exists(gda_dir):
+                for root, dirs, files in tf.io.gfile.walk(gda_dir):
+                    file_count += len(files)
+
+            percentage = (
+                (file_count / total_expected_files) * 100 if total_expected_files > 0 else 0
+            )
+            logging.info(
+                "Uploading weights to GCS... %d%% [%d/%d files written]",
+                int(percentage),
+                file_count,
+                total_expected_files,
+            )
+        except Exception:
+            pass
+        time.sleep(5)
+
+
+def convert_and_save(local_pytorch_dir: str, model_size: str, output_dir: str):
+    logging.info("Instantiating Hugging Face PyTorch Llama model...")
+    # Load weights in bfloat16 to reduce memory footprint from 120GB to 60GB (OOM safety)
+    llama_model = LlamaForCausalLM.from_pretrained(
+        local_pytorch_dir, torch_dtype=torch.bfloat16, device_map="cpu"
+    )
+
+    logging.info("Instantiating matching AXLearn Fuji-%s JAX model specs...", model_size)
+    fuji_kwargs = fuji.get_trainer_kwargs(
+        model_size,
+        vocab_size=(
+            128256 if "Llama-3" in FLAGS.model_id else 32000
+        ),  # Enforce correct Llama-3 vocab size (128256) instead of 131072
+        version=fuji.Version.V3_TIKTOKEN,  # V3_TIKTOKEN natively registers the Llama-3 8B configuration keys!
+    )
+
+    fuji_model_cfg = fuji_kwargs["model_cfg"]
+    fuji_model_cfg.set(name="model")  # Explicitly set name to satisfy config rules
+    fuji_model = fuji_model_cfg.instantiate(parent=None)
+
+    # Initialize empty structural parameters state spec (correct PRNGKey spelling)
+    dummy_prng = jax.random.PRNGKey(0)
+    empty_state_spec = fuji_model.initialize_parameters_recursively(prng_key=dummy_prng)
+
+    logging.info("Mapping PyTorch parameters into sharded JAX structures...")
+    # Map Torch weights natively to JAX parameters dict
+    jax_converted_params = param_converter.parameters_from_llama_3(llama_model, empty_state_spec)
+
+    logging.info("Deleting PyTorch model and clearing garbage collector...")
+    del llama_model
+    gc.collect()
+
+    logging.info("Serializing sharded JAX parameters to GCS output checkpoint: %s", output_dir)
+
+    # Temporarily bypass deepcopy entirely during instantiation to avoid Python 3.12 C-level pickling crashes
+    _orig_deepcopy = copy.deepcopy
+    copy.deepcopy = lambda x, memo=None: x
+    try:
+        storage_cfg = TensorStoreStateStorage.default_config().set(max_concurrent_gb=16)
+        storage = TensorStoreStateStorage(storage_cfg)
+    finally:
+        # Restore original deepcopy immediately
+        copy.deepcopy = _orig_deepcopy
+
+    # Save the model state natively under step_00000000 folder
+    step_dir = os.path.join(output_dir, "step_00000000")
+    tf.io.gfile.makedirs(step_dir)
+
+    # AXLearn checkpoint structure requires grouping inside 'model' scope
+    trainer_state = {"model": jax_converted_params}
+
+    # Start progress monitoring thread in background (Dynamically count exact GCS sharded files!)
+    total_expected_files = len(jax.tree_util.tree_leaves(jax_converted_params)) * 2
+    stop_event = threading.Event()
+    monitor_thread = threading.Thread(
+        target=monitor_upload_progress, args=(step_dir, total_expected_files, stop_event)
+    )
+    monitor_thread.daemon = True
+    monitor_thread.start()
+
+    try:
+        storage.save_to_dir(
+            step=0,
+            state=trainer_state,
+            ckpt_dir=step_dir,
+        )
+
+        logging.info("Waiting for asynchronous GCS serialization threads to fully commit...")
+        storage._manager.wait_until_finished()  # <--- Force main thread to block until all 70B weights are written!
+    finally:
+        stop_event.set()
+        monitor_thread.join(timeout=2)
+
+    logging.info("Weight conversion successfully completed and saved to GCS.")
+
+
+def main(_):
+    # Reshape flat device array to match ("data", "model") axis names
+    devices = np.array(jax.devices()).reshape(-1, 1)
+    mesh = jax.sharding.Mesh(
+        devices=devices,
+        axis_names=("data", "model"),
+    )
+
+    with mesh:
+        local_pytorch_dir = download_hf_model(FLAGS.model_id)
+        convert_and_save(local_pytorch_dir, FLAGS.model_size, FLAGS.output_dir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/axlearn/tools/download_qwen3_omni_checkpoint.py
+++ b/axlearn/tools/download_qwen3_omni_checkpoint.py
@@ -1,0 +1,341 @@
+# Copyright © 2026 Apple Inc.
+
+"""Utility script serializing Qwen MoE checkpoints into sharded JAX TensorStore arrays cleanly, fully aligned with JAX specs shapes."""
+
+import _thread
+import contextvars
+import copy
+import gc
+import os
+import select
+import threading
+import time
+
+import jax
+import numpy as np
+import tensorflow as tf
+import torch
+from absl import app, flags, logging
+from huggingface_hub import snapshot_download
+from transformers import AutoModelForTextToWaveform
+
+from axlearn.common.checkpointer import TensorStoreStateStorage
+from axlearn.experiments.text.gpt import qwen
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "model_id",
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    "Hugging Face model identifier repo path",
+    required=False,
+)
+flags.DEFINE_string(
+    "output_dir",
+    None,
+    "Destination GCS Bucket path or local folder for JAX checkpoints",
+    required=True,
+)
+
+
+def download_hf_model(model_id: str) -> str:
+    """Downloads PyTorch model checkpoints from Hugging Face Hub."""
+    logging.info("Downloading Hugging Face model: %s", model_id)
+    local_dir = snapshot_download(
+        repo_id=model_id,
+        ignore_patterns=["*.msgpack", "*.h5", "*.ot"],
+    )
+    logging.info("Model successfully downloaded locally to: %s", local_dir)
+    return local_dir
+
+
+def extract_numpy_weights(hf_model) -> dict:
+    """Extracts all PyTorch weights directly into contiguous pre-allocated NumPy arrays fully matching JAX 4D shapes."""
+    num_layers = len(hf_model.thinker.model.layers)
+    logging.info("Pre-allocating contiguous NumPy arrays for %d layers...", num_layers)
+
+    # Extract dimensions dynamically from JAX config (Vocab size is exactly 151936 for Qwen3)
+    vocab_size = qwen.QWEN3_VOCAB_SIZE
+    first_layer = hf_model.thinker.model.layers[0]
+    hidden_dim = first_layer.input_layernorm.weight.shape[0]
+    num_experts = 128
+
+    gate_up_fused = first_layer.mlp.experts.gate_up_proj.detach().cpu().to(torch.float32).numpy()
+    intermediate_dim = gate_up_fused.shape[1] // 2
+
+    flat_params = {
+        "token_emb": hf_model.thinker.model.embed_tokens.weight.detach()
+        .cpu()
+        .to(torch.float32)
+        .numpy()[:vocab_size, :],  # Slice padded rows back to base 151936
+        "lm_head": hf_model.thinker.lm_head.weight.detach()
+        .cpu()
+        .to(torch.float32)
+        .numpy()[:vocab_size, :],  # Slice padded rows back to base 151936
+        "output_norm": hf_model.thinker.model.norm.weight.detach().cpu().to(torch.float32).numpy(),
+        # Pre-allocated contiguous JAX-aligned arrays
+        "input_norm": np.empty((num_layers, hidden_dim), dtype=np.float32),
+        "post_norm": np.empty((num_layers, hidden_dim), dtype=np.float32),
+        "qkv": np.empty(
+            (num_layers, hidden_dim, 40, 128), dtype=np.float32
+        ),  # 4D JAX shape [layers, hidden_dim, 40, 128]
+        "o": np.empty(
+            (num_layers, hidden_dim, 32, 128), dtype=np.float32
+        ),  # 4D JAX shape [layers, hidden_dim, 32, 128]
+        "scale_query": np.empty((num_layers, 128), dtype=np.float32),  # Attention RMSNorm scale
+        "scale_key": np.empty((num_layers, 128), dtype=np.float32),  # Attention RMSNorm scale
+        "moe_gate_weight": np.empty((num_layers, hidden_dim, num_experts), dtype=np.float32),
+        "moe_wi_0": np.empty(
+            (num_layers, num_experts, hidden_dim, intermediate_dim), dtype=np.float32
+        ),
+        "moe_wi_1": np.empty(
+            (num_layers, num_experts, hidden_dim, intermediate_dim), dtype=np.float32
+        ),
+        "moe_wo": np.empty(
+            (num_layers, num_experts, intermediate_dim, hidden_dim), dtype=np.float32
+        ),
+    }
+
+    # 2. Extract layers parameters sequentially directly into the pre-allocated slots
+    for i in range(num_layers):
+        layer = hf_model.thinker.model.layers[i]
+        logging.info(
+            "Extracting layer %d/%d directly into pre-allocated memory...", i + 1, num_layers
+        )
+
+        flat_params["input_norm"][i] = (
+            layer.input_layernorm.weight.detach().cpu().to(torch.float32).numpy()
+        )
+        flat_params["post_norm"][i] = (
+            layer.post_attention_layernorm.weight.detach().cpu().to(torch.float32).numpy()
+        )
+
+        # Attention projections GQA concatenation (Reshaping to 4D [hidden_dim, heads, head_dim] instead of flattening)
+        q = layer.self_attn.q_proj.weight.detach().cpu().to(torch.float32).numpy()  # [4096, 2048]
+        k = layer.self_attn.k_proj.weight.detach().cpu().to(torch.float32).numpy()  # [512, 2048]
+        v = layer.self_attn.v_proj.weight.detach().cpu().to(torch.float32).numpy()  # [512, 2048]
+
+        q = q.reshape(32, 128, hidden_dim)
+        k = k.reshape(4, 128, hidden_dim)
+        v = v.reshape(4, 128, hidden_dim)
+
+        qkv_layer = np.concatenate([q, k, v], axis=0)  # shape [40, 128, 2048]
+        flat_params["qkv"][i] = qkv_layer.transpose(2, 0, 1)  # Transpose to [2048, 40, 128]
+
+        # Extract o_proj.weight and reshape to [hidden_dim, 32, 128]
+        o = layer.self_attn.o_proj.weight.detach().cpu().to(torch.float32).numpy()  # [2048, 4096]
+        flat_params["o"][i] = o.reshape(hidden_dim, 32, 128)
+
+        # Extract Attention Query/Key RMSNorm scales
+        flat_params["scale_query"][i] = (
+            layer.self_attn.q_norm.weight.detach().cpu().to(torch.float32).numpy()
+        )
+        flat_params["scale_key"][i] = (
+            layer.self_attn.k_norm.weight.detach().cpu().to(torch.float32).numpy()
+        )
+
+        # Sparse MoE parameters extraction
+        if hasattr(layer, "mlp"):
+            flat_params["moe_gate_weight"][i] = (
+                layer.mlp.gate.weight.detach().cpu().to(torch.float32).numpy().T
+            )
+
+            gate_up_fused = layer.mlp.experts.gate_up_proj.detach().cpu().to(torch.float32).numpy()
+            gate_up = gate_up_fused.reshape(num_experts, 2, intermediate_dim, hidden_dim)
+
+            flat_params["moe_wi_0"][i] = gate_up[:, 0, :, :].transpose(0, 2, 1)
+            flat_params["moe_wi_1"][i] = gate_up[:, 1, :, :].transpose(0, 2, 1)
+
+            down_fused = layer.mlp.experts.down_proj.detach().cpu().to(torch.float32).numpy()
+            flat_params["moe_wo"][i] = down_fused.transpose(0, 2, 1)
+
+        # Free PyTorch layer memory immediately
+        hf_model.thinker.model.layers[i] = None
+        gc.collect()
+
+    return flat_params
+
+
+def populate_jax_state(flat_params: dict) -> dict:
+    """Structures the pre-allocated NumPy arrays directly into JAX Arrays using progressive sequential memory collection."""
+    logging.info("Structuring JAX parameter tree natively with pre-allocated JAX Arrays...")
+    import jax.numpy as jnp
+
+    # Initialize JAX parameter variables sequentially, executing gc.collect() after each major pop
+    emb_weight = jnp.array(flat_params.pop("token_emb"))
+    gc.collect()
+
+    lm_head_weight = jnp.array(flat_params.pop("lm_head"))
+    gc.collect()
+
+    output_norm_scale = jnp.array(flat_params.pop("output_norm"))
+    gc.collect()
+
+    input_norm_scale = jnp.array(flat_params.pop("input_norm"))
+    gc.collect()
+
+    qkv_weight = jnp.array(flat_params.pop("qkv"))
+    gc.collect()
+
+    o_weight = jnp.array(flat_params.pop("o"))
+    gc.collect()
+
+    scale_query_scale = jnp.array(flat_params.pop("scale_query"))
+    gc.collect()
+
+    scale_key_scale = jnp.array(flat_params.pop("scale_key"))
+    gc.collect()
+
+    post_norm_scale = jnp.array(flat_params.pop("post_norm"))
+    gc.collect()
+
+    gate_weight = jnp.array(flat_params.pop("moe_gate_weight"))
+    gc.collect()
+
+    wi_0_weight = jnp.array(flat_params.pop("moe_wi_0"))
+    gc.collect()
+
+    wi_1_weight = jnp.array(flat_params.pop("moe_wi_1"))
+    gc.collect()
+
+    wo_weight = jnp.array(flat_params.pop("moe_wo"))
+    gc.collect()
+
+    # Reconstruct the exact nested JAX parameters dictionary expected by SpmdTrainer natively
+    jax_params = {
+        "decoder": {
+            "emb": {"token_emb": {"weight": emb_weight}},
+            "lm_head": {"weight": lm_head_weight},
+            "output_norm": {"scale": output_norm_scale},
+            "transformer": {
+                "repeat": {
+                    "layer": {
+                        "self_attention": {
+                            "norm": {"scale": input_norm_scale},
+                            "attention": {
+                                "i_proj": {"i_proj": {"qkv_proj": {"weight": qkv_weight}}},
+                                "o_proj": {"weight": o_weight},
+                                "scale_query": {"norm": {"scale": scale_query_scale}},
+                                "scale_key": {"norm": {"scale": scale_key_scale}},
+                            },
+                        },
+                        "feed_forward": {
+                            "norm": {"scale": post_norm_scale},
+                            "gate_weight": gate_weight,
+                            "wi_0_weight": wi_0_weight,
+                            "wi_1_weight": wi_1_weight,
+                            "wo_weight": wo_weight,
+                        },
+                    }
+                }
+            },
+        }
+    }
+    return jax_params
+
+
+def monitor_upload_progress(step_dir: str, total_expected_files: int, stop_event: threading.Event):
+    """Polls the GCS output folder recursively to count successfully written files."""
+    logging.info("Starting GCS upload progress monitor thread...")
+
+    while not stop_event.is_set():
+        try:
+            gda_dir = os.path.join(step_dir, "gda")
+            file_count = 0
+            if tf.io.gfile.exists(gda_dir):
+                for root, dirs, files in tf.io.gfile.walk(gda_dir):
+                    file_count += len(files)
+
+            percentage = (
+                (file_count / total_expected_files) * 100 if total_expected_files > 0 else 0
+            )
+            logging.info(
+                "Uploading weights to GCS... %d%% [%d/%d files written]",
+                int(percentage),
+                file_count,
+                total_expected_files,
+            )
+        except Exception:
+            pass
+        time.sleep(5)
+
+
+def convert_and_save(local_pytorch_dir: str, output_dir: str):
+    logging.info("Loading Hugging Face PyTorch Qwen Model...")
+    hf_model = AutoModelForTextToWaveform.from_pretrained(
+        local_pytorch_dir, torch_dtype=torch.bfloat16, trust_remote_code=True, device_map="cpu"
+    )
+
+    # --- Step 1: Pre-allocate and Extract contiguous weights ---
+    flat_params = extract_numpy_weights(hf_model)
+
+    logging.info("Deleting PyTorch model and clearing garbage collector...")
+    del hf_model
+    gc.collect()
+
+    # --- Step 2: Structure JAX parameters tree natively ---
+    jax_params = populate_jax_state(flat_params)
+
+    logging.info("Purging intermediate flat parameters dictionary...")
+    del flat_params
+    gc.collect()
+
+    # --- Step 3: Serialize and Save ---
+    logging.info("Serializing sharded JAX parameters to GCS path...")
+
+    # Temporarily bypass deepcopy entirely during instantiation to avoid Python 3.12 C-level pickling crashes
+    _orig_deepcopy = copy.deepcopy
+    copy.deepcopy = lambda x, memo=None: x
+    try:
+        storage_cfg = TensorStoreStateStorage.default_config().set(max_concurrent_gb=16)
+        storage = TensorStoreStateStorage(storage_cfg)
+    finally:
+        # Restore original deepcopy immediately
+        copy.deepcopy = _orig_deepcopy
+
+    # Save the model state natively under step_00000000 folder
+    step_dir = os.path.join(output_dir, "step_00000000")
+    tf.io.gfile.makedirs(step_dir)
+
+    # Mapped structure expected inside trainer_state
+    trainer_state = {"model": jax_params}
+
+    # Start progress monitoring thread in background (Dynamically count exact sharded JAX leaves!)
+    total_expected_files = len(jax.tree_util.tree_leaves(jax_params))
+    stop_event = threading.Event()
+    monitor_thread = threading.Thread(
+        target=monitor_upload_progress, args=(step_dir, total_expected_files, stop_event)
+    )
+
+    monitor_thread.daemon = True
+    monitor_thread.start()
+
+    try:
+        storage.save_to_dir(
+            step=0,
+            state=trainer_state,
+            ckpt_dir=step_dir,
+        )
+
+        logging.info("Waiting for asynchronous GCS serialization threads to fully commit...")
+        storage._manager.wait_until_finished()  # <--- Force main thread to block until all 60GB are written!
+    finally:
+        stop_event.set()
+        monitor_thread.join(timeout=2)
+
+    logging.info("Checkpoints successfully sharded and saved to GCS.")
+
+
+def main(_):
+    devices = np.array(jax.devices()).reshape(-1, 1)
+    mesh = jax.sharding.Mesh(
+        devices=devices,
+        axis_names=("data", "model"),
+    )
+
+    with mesh:
+        local_pytorch_dir = download_hf_model(FLAGS.model_id)
+        convert_and_save(local_pytorch_dir, FLAGS.output_dir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/axlearn/tools/validate_llama3_checkpoint.py
+++ b/axlearn/tools/validate_llama3_checkpoint.py
@@ -1,0 +1,201 @@
+# Copyright © 2026 Apple Inc.
+
+"""Utility script validating a converted LLaMA JAX TensorStore checkpoint against the original Hugging Face PyTorch parameters for numerical identity."""
+
+
+import jax
+import numpy as np
+import torch
+from absl import app, flags, logging
+from transformers import LlamaForCausalLM
+
+from axlearn.common.checkpointer import TensorStoreStateStorage
+from axlearn.experiments.text.gpt import fuji
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "model_id",
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "Hugging Face model identifier repo path",
+    required=False,
+)
+flags.DEFINE_string(
+    "model_size", "8B", "Fuji target model size (test, 1B, 3B, 8B, 70B)", required=False
+)
+flags.DEFINE_string(
+    "ckpt_dir",
+    None,
+    "The GCS JAX checkpoint folder to validate (must point to step_00000000/)",
+    required=True,
+)
+
+
+def validate_checkpoint(ckpt_dir: str, model_size: str):
+    logging.info("Loading original Hugging Face PyTorch Llama model for numerical validation...")
+    hf_model = LlamaForCausalLM.from_pretrained(
+        FLAGS.model_id,
+        torch_dtype=torch.bfloat16,  # Load in bfloat16 (OOM-safe 60GB footprint)
+        device_map="cpu",
+    )
+
+    logging.info("Restoring sharded JAX parameters from target checkpoint: %s", ckpt_dir)
+
+    # Temporarily bypass deepcopy entirely during instantiation to avoid Python 3.12 C-level pickling crashes
+    import copy
+
+    _orig_deepcopy = copy.deepcopy
+    copy.deepcopy = lambda x, memo=None: x
+    try:
+        storage = TensorStoreStateStorage(TensorStoreStateStorage.default_config())
+    finally:
+        copy.deepcopy = _orig_deepcopy
+
+    # 1. Instantiate matching JAX Fuji model specs to get the structural template for restoration
+    logging.info("Instantiating JAX model specs template for restoration...")
+    fuji_kwargs = fuji.get_trainer_kwargs(
+        model_size,
+        vocab_size=(
+            128256 if "Llama-3" in FLAGS.model_id else 32000
+        ),  # Enforce correct Llama-3 vocab size (128256)
+        version=fuji.Version.V3_TIKTOKEN,  # V3_TIKTOKEN natively registers the Llama-3 8B configuration keys!
+    )
+
+    fuji_model_cfg = fuji_kwargs["model_cfg"]
+    fuji_model_cfg.set(name="model")
+    fuji_model = fuji_model_cfg.instantiate(parent=None)
+
+    dummy_prng = jax.random.PRNGKey(0)
+    # Evaluate shapes recursively without allocating physical memory arrays to prevent OOM thrashing
+    empty_state_spec = jax.eval_shape(
+        lambda: fuji_model.initialize_parameters_recursively(prng_key=dummy_prng)
+    )
+
+    # Convert JAX ShapeDtypeStruct leaves into standard AXLearn TensorSpec objects recursively
+    # This satisfies checkpointer type assertions and prevents dictionary type mismatches!
+    from axlearn.common.utils import TensorSpec
+
+    empty_trainer_state = jax.tree.map(
+        lambda x: TensorSpec(shape=x.shape, dtype=x.dtype), {"model": empty_state_spec}
+    )
+
+    # 2. Restore sharded parameters dictionary from GCS natively using the structural template
+    logging.info("Reading sharded parameters from GCS...")
+    restored_state = storage.restore_from_dir(
+        step=0,
+        state=empty_trainer_state,
+        ckpt_dir=ckpt_dir,
+    )
+    jax_model_params = restored_state["model"]
+
+    logging.info("Verifying structural shapes and numerical identity...")
+    vocab_size = 128256 if "Llama-3" in FLAGS.model_id else 32000
+
+    # 3. Verify Embeddings
+    hf_emb = (
+        hf_model.model.embed_tokens.weight.detach().cpu().to(torch.float32).numpy()[:vocab_size, :]
+    )
+    jax_emb = jax_model_params["decoder"]["emb"]["token_emb"]["weight"]
+    assert (
+        hf_emb.shape == jax_emb.shape
+    ), f"Embedding shape mismatch! HF: {hf_emb.shape}, JAX: {jax_emb.shape}"
+    emb_diff = np.max(np.abs(hf_emb - jax_emb))
+    logging.info("token_emb absolute max difference: %e", emb_diff)
+    assert emb_diff < 1e-5, f"Embedding numerical discrepancy exceeded threshold: {emb_diff}"
+
+    # 4. Verify LM Head (LLaMA-3 lm_head weight has shape [vocab_size, hidden_dim] natively, saved without transposing)
+    hf_head = hf_model.lm_head.weight.detach().cpu().to(torch.float32).numpy()[:vocab_size, :]
+    jax_head = jax_model_params["decoder"]["lm_head"]["weight"]
+    assert (
+        hf_head.shape == jax_head.shape
+    ), f"LM Head shape mismatch! HF: {hf_head.shape}, JAX: {jax_head.shape}"
+    head_diff = np.max(np.abs(hf_head - jax_head))
+    logging.info("lm_head absolute max difference: %e", head_diff)
+    assert head_diff < 1e-5, f"LM Head numerical discrepancy exceeded threshold: {head_diff}"
+
+    # 5. Verify Layer 1 attention projections
+    first_layer = hf_model.model.layers[0]
+    hidden_dim = first_layer.input_layernorm.weight.shape[0]
+
+    # Retrieve restored attention qkv weights (which are 4D JAX layout [hidden_dim, 40, 128] for 8B)
+    jax_qkv = jax_model_params["decoder"]["transformer"]["repeat"]["layer"]["self_attention"][
+        "attention"
+    ]["i_proj"]["i_proj"]["qkv_proj"]["weight"][0]
+
+    num_q_heads = hf_model.config.num_attention_heads
+    num_kv_heads = hf_model.config.num_key_value_heads
+    head_dim = hidden_dim // num_q_heads
+
+    # Import AXLearn's native RoPE permutation function directly
+    from axlearn.common.param_converter import _permute_q_k_for_rope
+
+    # Retrieve raw PyTorch tensors
+    q_pt = first_layer.self_attn.q_proj.weight.detach().cpu()
+    k_pt = first_layer.self_attn.k_proj.weight.detach().cpu()
+    v_pt = first_layer.self_attn.v_proj.weight.detach().cpu()
+
+    # Reshape PyTorch tensors to [heads, head_dim, hidden_dim] as expected by AXLearn
+    q_pt = q_pt.reshape(num_q_heads, head_dim, hidden_dim)
+    k_pt = k_pt.reshape(num_kv_heads, head_dim, hidden_dim)
+    v_pt = v_pt.reshape(num_kv_heads, head_dim, hidden_dim)
+
+    # Apply native AXLearn permutation recursively
+    q_pt = _permute_q_k_for_rope(q_pt)
+    k_pt = _permute_q_k_for_rope(k_pt)
+
+    # Convert to Float32 and NumPy safely
+    q = q_pt.to(torch.float32).numpy()
+    k = k_pt.to(torch.float32).numpy()
+    v = v_pt.to(torch.float32).numpy()
+
+    # Statically concatenate and transpose to match JAX 4D sharded layout [hidden_dim, 40, 128]
+    hf_qkv = np.concatenate([q, k, v], axis=0).transpose(2, 0, 1)
+
+    assert (
+        hf_qkv.shape == jax_qkv.shape
+    ), f"QKV shape mismatch! HF: {hf_qkv.shape}, JAX: {jax_qkv.shape}"
+    qkv_diff = np.max(np.abs(hf_qkv - jax_qkv))
+    logging.info("Layer 1 QKV absolute max difference: %e", qkv_diff)
+    assert qkv_diff < 1e-5, f"QKV numerical discrepancy exceeded threshold: {qkv_diff}"
+
+    # Retrieve restored attention o_proj weights (4D JAX layout [hidden_dim, num_heads, head_dim])
+    jax_o = jax_model_params["decoder"]["transformer"]["repeat"]["layer"]["self_attention"][
+        "attention"
+    ]["o_proj"]["weight"][0]
+    o = first_layer.self_attn.o_proj.weight.detach().cpu().to(torch.float32).numpy()
+    hf_o = o.reshape(hidden_dim, num_q_heads, head_dim)
+
+    assert hf_o.shape == jax_o.shape, f"O Proj shape mismatch! HF: {hf_o.shape}, JAX: {jax_o.shape}"
+    o_diff = np.max(np.abs(hf_o - jax_o))
+    logging.info("Layer 1 O Proj absolute max difference: %e", o_diff)
+    assert o_diff < 1e-5, f"O Proj numerical discrepancy exceeded threshold: {o_diff}"
+
+    # 6. Verify Layer 1 Feed Forward MLP projections
+    jax_wi_0 = jax_model_params["decoder"]["transformer"]["repeat"]["layer"]["feed_forward"][
+        "linear1_0"
+    ]["weight"][0]
+    hf_wi_0 = first_layer.mlp.gate_proj.weight.detach().cpu().to(torch.float32).numpy().T
+    assert (
+        hf_wi_0.shape == jax_wi_0.shape
+    ), f"gate_proj shape mismatch! HF: {hf_wi_0.shape}, JAX: {jax_wi_0.shape}"
+    wi_0_diff = np.max(np.abs(hf_wi_0 - jax_wi_0))
+    logging.info("Layer 1 gate_proj absolute max difference: %e", wi_0_diff)
+    assert wi_0_diff < 1e-5, f"gate_proj numerical discrepancy exceeded threshold: {wi_0_diff}"
+
+    logging.info("\n==============================================================")
+    logging.info("VALIDATION SUCCESSFUL: Checkpoint is 100% numerically identical to Hugging Face!")
+    logging.info("==============================================================")
+
+
+def main(_):
+    devices = np.array(jax.devices()).reshape(-1, 1)
+    mesh = jax.sharding.Mesh(
+        devices=devices,
+        axis_names=("data", "model"),
+    )
+
+    with mesh:
+        validate_checkpoint(FLAGS.ckpt_dir, FLAGS.model_size)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/axlearn/tools/validate_qwen3_omni_checkpoint.py
+++ b/axlearn/tools/validate_qwen3_omni_checkpoint.py
@@ -1,0 +1,189 @@
+# Copyright © 2026 Apple Inc.
+
+"""Utility script validating a converted JAX TensorStore checkpoint against the original Hugging Face PyTorch parameters for numerical identity."""
+
+import os
+
+import jax
+import numpy as np
+import torch
+from absl import app, flags, logging
+from transformers import AutoModelForTextToWaveform
+
+from axlearn.common.checkpointer import TensorStoreStateStorage
+from axlearn.experiments.text.gpt import qwen
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "model_id",
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    "Hugging Face model identifier repo path",
+    required=False,
+)
+flags.DEFINE_string(
+    "ckpt_dir",
+    None,
+    "The GCS JAX checkpoint folder to validate (must point to step_00000000/)",
+    required=True,
+)
+
+
+def validate_checkpoint(ckpt_dir: str):
+    logging.info("Loading original Hugging Face PyTorch model for numerical validation...")
+    hf_model = AutoModelForTextToWaveform.from_pretrained(
+        FLAGS.model_id,
+        torch_dtype=torch.bfloat16,  # <--- Load in bfloat16 (OOM-safe 60GB footprint)
+        trust_remote_code=True,
+        device_map="cpu",
+    )
+
+    logging.info("Restoring sharded JAX parameters from target checkpoint: %s", ckpt_dir)
+
+    # Temporarily bypass deepcopy entirely during instantiation to avoid Python 3.12 C-level pickling crashes
+    import contextvars
+    import copy
+    import select
+
+    _orig_deepcopy = copy.deepcopy
+    copy.deepcopy = lambda x, memo=None: x
+    try:
+        storage = TensorStoreStateStorage(TensorStoreStateStorage.default_config())
+    finally:
+        copy.deepcopy = _orig_deepcopy
+
+    # Instantiate matching JAX model specs to get the structural template for restoration
+    logging.info("Instantiating JAX model specs template for restoration...")
+    qwen_kwargs = qwen.get_trainer_kwargs(
+        "30B-A3B",
+        vocab_size=qwen.QWEN3_VOCAB_SIZE,
+        batch_size=1024,
+        max_sequence_length=1024,
+    )
+
+    qwen_kwargs["model_cfg"].set(name="model")
+    qwen_model = qwen_kwargs["model_cfg"].instantiate(parent=None)
+
+    dummy_prng = jax.random.PRNGKey(0)
+    logging.info("[eshenlog] before jax.eval_shape")
+    # Evaluate shapes recursively without allocating physical memory arrays to prevent OOM thrashing
+    empty_state_spec = jax.eval_shape(
+        lambda: qwen_model.initialize_parameters_recursively(prng_key=dummy_prng)
+    )
+    logging.info("[eshenlog] after jax.eval_shape")
+
+    # Convert JAX ShapeDtypeStruct leaves into standard AXLearn TensorSpec objects recursively
+    # This satisfies checkpointer type assertions and prevents dictionary type mismatches!
+    from axlearn.common.utils import TensorSpec
+
+    empty_trainer_state = jax.tree.map(
+        lambda x: TensorSpec(shape=x.shape, dtype=x.dtype), {"model": empty_state_spec}
+    )
+
+    # Restore sharded parameters dictionary from GCS natively using the structural template
+    logging.info("Reading sharded parameters from GCS...")
+    restored_state = storage.restore_from_dir(
+        step=0,
+        state=empty_trainer_state,
+        ckpt_dir=ckpt_dir,
+    )
+    jax_model_params = restored_state["model"]
+
+    logging.info("Verifying structural shapes and numerical identity...")
+
+    vocab_size = qwen.QWEN3_VOCAB_SIZE
+
+    # 1. Verify Embeddings (Slicing padded rows to base vocab_size, casting to float32 to avoid BFloat16 numpy exceptions)
+    hf_emb = (
+        hf_model.thinker.model.embed_tokens.weight.detach()
+        .cpu()
+        .to(torch.float32)
+        .numpy()[:vocab_size, :]
+    )
+    jax_emb = jax_model_params["decoder"]["emb"]["token_emb"]["weight"]
+    assert (
+        hf_emb.shape == jax_emb.shape
+    ), f"Embedding shape mismatch! HF: {hf_emb.shape}, JAX: {jax_emb.shape}"
+    emb_diff = np.max(np.abs(hf_emb - jax_emb))
+    logging.info("token_emb absolute max difference: %e", emb_diff)
+    assert emb_diff < 1e-5, f"Embedding numerical discrepancy exceeded threshold: {emb_diff}"
+
+    # 2. Verify LM Head (Saved without .T transposition, comparing sliced base shape, casting to float32)
+    hf_head = (
+        hf_model.thinker.lm_head.weight.detach().cpu().to(torch.float32).numpy()[:vocab_size, :]
+    )
+    jax_head = jax_model_params["decoder"]["lm_head"]["weight"]
+    assert (
+        hf_head.shape == jax_head.shape
+    ), f"LM Head shape mismatch! HF: {hf_head.shape}, JAX: {jax_head.shape}"
+    head_diff = np.max(np.abs(hf_head - jax_head))
+    logging.info("lm_head absolute max difference: %e", head_diff)
+    assert head_diff < 1e-5, f"LM Head numerical discrepancy exceeded threshold: {head_diff}"
+
+    # 3. Verify Layer 1 attention projections (4D layouts mapping)
+    first_layer = hf_model.thinker.model.layers[0]
+    hidden_dim = first_layer.input_layernorm.weight.shape[0]
+
+    # Retrieve restored attention qkv weights (which are 4D [hidden_dim, 40, 128])
+    jax_qkv = jax_model_params["decoder"]["transformer"]["repeat"]["layer"]["self_attention"][
+        "attention"
+    ]["i_proj"]["i_proj"]["qkv_proj"]["weight"][0]
+    q = first_layer.self_attn.q_proj.weight.detach().cpu().to(torch.float32).numpy()
+    k = first_layer.self_attn.k_proj.weight.detach().cpu().to(torch.float32).numpy()
+    v = first_layer.self_attn.v_proj.weight.detach().cpu().to(torch.float32).numpy()
+
+    q = q.reshape(32, 128, hidden_dim)
+    k = k.reshape(4, 128, hidden_dim)
+    v = v.reshape(4, 128, hidden_dim)
+    hf_qkv = np.concatenate([q, k, v], axis=0).transpose(
+        2, 0, 1
+    )  # Transpose to [hidden_dim, 40, 128]
+
+    assert (
+        hf_qkv.shape == jax_qkv.shape
+    ), f"QKV shape mismatch! HF: {hf_qkv.shape}, JAX: {jax_qkv.shape}"
+    qkv_diff = np.max(np.abs(hf_qkv - jax_qkv))
+    logging.info("Layer 1 QKV absolute max difference: %e", qkv_diff)
+    assert qkv_diff < 1e-5, f"QKV numerical discrepancy exceeded threshold: {qkv_diff}"
+
+    # Retrieve restored attention o_proj weights (which are 4D [hidden_dim, 32, 128])
+    jax_o = jax_model_params["decoder"]["transformer"]["repeat"]["layer"]["self_attention"][
+        "attention"
+    ]["o_proj"]["weight"][0]
+    o = first_layer.self_attn.o_proj.weight.detach().cpu().to(torch.float32).numpy()
+    hf_o = o.reshape(hidden_dim, 32, 128)
+
+    assert hf_o.shape == jax_o.shape, f"O Proj shape mismatch! HF: {hf_o.shape}, JAX: {jax_o.shape}"
+    o_diff = np.max(np.abs(hf_o - jax_o))
+    logging.info("Layer 1 O Proj absolute max difference: %e", o_diff)
+    assert o_diff < 1e-5, f"O Proj numerical discrepancy exceeded threshold: {o_diff}"
+
+    # 5. Verify Layer 1 Sparse MoE parameters
+    jax_moe_gate = jax_model_params["decoder"]["transformer"]["repeat"]["layer"]["feed_forward"][
+        "gate_weight"
+    ][0]
+    hf_moe_gate = first_layer.mlp.gate.weight.detach().cpu().to(torch.float32).numpy().T
+    assert (
+        hf_moe_gate.shape == jax_moe_gate.shape
+    ), f"MoE Gate shape mismatch! HF: {hf_moe_gate.shape}, JAX: {jax_moe_gate.shape}"
+    gate_diff = np.max(np.abs(hf_moe_gate - jax_moe_gate))
+    logging.info("Layer 1 MoE Gate absolute max difference: %e", gate_diff)
+    assert gate_diff < 1e-5, f"MoE Gate numerical discrepancy exceeded threshold: {gate_diff}"
+
+    logging.info("\n==============================================================")
+    logging.info("VALIDATION SUCCESSFUL: Checkpoint is 100% numerically identical to Hugging Face!")
+    logging.info("==============================================================")
+
+
+def main(_):
+    devices = np.array(jax.devices()).reshape(-1, 1)
+    mesh = jax.sharding.Mesh(
+        devices=devices,
+        axis_names=("data", "model"),
+    )
+
+    with mesh:
+        validate_checkpoint(FLAGS.ckpt_dir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ core = [
     "prefixed==0.9.0", # For formatting file sizes, param counts, etc.
     "grain==0.2.11", # Grain input processing. 0.2.6 onwards supports macos.
     "tokamax",
+    "tokenizers>=0.19.0",  # Core dependency for LLaMA-3 TikToken vocabs!
 ]
 # Apple Silicon dependencies.
 # Need to run `conda install -c apple tensorflow-deps` separately.


### PR DESCRIPTION
# Overview
Group Relative Policy Optimization (GRPO) is a reinforcement learning algorithm designed to efficiently train Large Language Models (LLMs) without requiring a Critic model. In standard PPO, a Critic model (often of equal size to the Actor) must be kept in memory to estimate baseline value functions for advantage computation. GRPO eliminates this memory overhead entirely. Instead, for each input prompt, GRPO samples a group of distinct generations (rollouts) from the Actor policy, scores them using a reward model or rule-based function, and computes relative advantages by normalizing the rewards within that group (subtracting the group mean and dividing by the group standard deviation). The policy is then optimized using a PPO-style clipped surrogate objective alongside a KL divergence constraint against a frozen Reference model to prevent policy drift.

# Separate Sampler and Trainer with Pathways
The generation and training workloads are decoupled onto distinct hardware partitions within a global mesh. For example, half of the available accelerators are assigned to a [rollout_mesh](https://github.com/eshen1991/axlearn/blob/rl-example-pathways/axlearn/common/grpo_trainer.py#L58) optimized for low-latency autoregressive decoding (using tensor/data parallelism), while the other half forms a [trainer_mesh](https://github.com/eshen1991/axlearn/blob/rl-example-pathways/axlearn/common/grpo_trainer.py#L55) optimized for FSDP-based gradient updates. Weights are synchronized(via [jax.device_put](https://github.com/eshen1991/axlearn/blob/rl-example-pathways/axlearn/common/grpo_trainer.py#L512)) across meshes after each training step.

See [grpo_example_readme](https://github.com/eshen1991/axlearn/blob/rl-example-pathways/axlearn/experiments/text/gpt/grpo_example.md) for details